### PR TITLE
Add project information to example YAML file

### DIFF
--- a/example_config/ferraris_meter.yaml
+++ b/example_config/ferraris_meter.yaml
@@ -6,6 +6,9 @@
 esphome:
   name: ferraris-meter
   friendly_name: Stromzähler
+  project:
+    name: jensrossbach.ferraris_meter
+    version: 1.1.0
 
 # example ESP8266 firmware (can be replaced by appropriate configuration)
 esp8266:


### PR DESCRIPTION
This pull request adds example project information following the Ferraris Meter project version to the example YAML file.

Closes #4