### PR TITLE
Use release tag in GitHub URL of example configuration

### DIFF
--- a/example_config/ferraris_meter.yaml
+++ b/example_config/ferraris_meter.yaml
@@ -16,7 +16,7 @@ esp8266:
 
 # include Ferraris component (mandatory)
 external_components:
-  - source: github://jensrossbach/esphome-ferraris-meter
+  - source: github://jensrossbach/esphome-ferraris-meter@v1.1.0
     components: [ferraris]
 
 # enable logging (optional)


### PR DESCRIPTION
This pull request adds a release tag to the GitHub URL in the example configuration in order to bind it to the release and thereby to the code base it belongs to.

Resolves #10 