### PR TITLE
Example configuration for multiple Ferraris electricity meters

### DIFF
--- a/example_config/ferraris_meter.yaml
+++ b/example_config/ferraris_meter.yaml
@@ -1,6 +1,6 @@
 # This is an example configuration for an ESPHome firmware to measure the
-# current power and overall energy consumption using an analog Ferraris
-# electricity meter
+# current power and overall energy consumption using a Ferraris electricity
+# meter
 
 # generic configuration (to be adapted)
 esphome:
@@ -48,9 +48,8 @@ captive_portal:
 
 # Ferraris component (mandatory)
 ferraris:
+  id: ferraris_meter
   pin: GPIO4
-  rotations_per_kwh: 75
-  low_state_threshold: 400  # milliseconds
   energy_start_value: last_energy_value
 
 # numeric sensors

--- a/example_config/ferraris_meter_multi.yaml
+++ b/example_config/ferraris_meter_multi.yaml
@@ -1,0 +1,182 @@
+# This is an example configuration for an ESPHome firmware to measure the
+# current power and overall energy consumption using a Ferraris electricity
+# meter
+
+# In this variant, the configuration to observe multiple Ferraris electricity
+# meters with a single ESP microcontroller is demonstrated.
+
+# generic configuration (to be adapted)
+esphome:
+  name: ferraris-meter
+  friendly_name: Stromzähler
+  project:
+    name: jensrossbach.ferraris_meter
+    version: 1.2.0
+
+# example ESP8266 firmware (can be replaced by appropriate configuration)
+esp8266:
+  board: esp01_1m
+
+# include Ferraris component (mandatory)
+external_components:
+  - source: github://jensrossbach/esphome-ferraris-meter@v1.2.0
+    components: [ferraris]
+
+# enable logging (optional)
+logger:
+  level: INFO
+
+# enable Home Assistant API (mandatory if used with Home Assistant, alternatively configure MQTT)
+api:
+  encryption:
+    key: !secret ha_api_key
+
+# enable over-the-air updates (recommended)
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+# enable Wi-Fi (mandatory)
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+  # enable fallback hotspot (captive portal) in case Wi-Fi connection fails
+  ap:
+    ssid: Ferraris Meter Fallback Hotspot
+    password: !secret fallback_hs_password
+
+# needed for fallback hotspot (see above)
+captive_portal:
+
+# Ferraris component (mandatory)
+ferraris:
+  - id: ferraris_meter_1
+    pin: GPIO4
+    rotations_per_kwh: 75
+    energy_start_value: last_energy_value_1
+  - id: ferraris_meter_1
+    pin: GPIO5
+    rotations_per_kwh: 100
+    energy_start_value: last_energy_value_2
+
+# numeric sensors
+sensor:
+  - platform: ferraris
+    ferraris_id: ferraris_meter_1
+    # sensor for current power consumption of first electricity meter
+    power_consumption:
+      name: Momentanverbrauch 1
+    # sensor for energy meter reading of first electricity meter
+    energy_meter:
+      name: Verbrauchszähler 1
+  - platform: ferraris
+    ferraris_id: ferraris_meter_2
+    # sensor for current power consumption of second electricity meter
+    power_consumption:
+      name: Momentanverbrauch 2
+    # sensor for energy meter reading of second electricity meter
+    energy_meter:
+      name: Verbrauchszähler 2
+  # sensor for Wi-Fi signal strength
+  - platform: wifi_signal
+    name: Wi-Fi Signal
+    update_interval: 60s
+
+# binary sensors
+binary_sensor:
+  - platform: ferraris
+    ferraris_id: ferraris_meter_1
+    # sensor for indicating detected rotation on first elecricity meter during calibration mode
+    rotation_indicator:
+      name: Umdrehungsindikator 1
+  - platform: ferraris
+    ferraris_id: ferraris_meter_2
+    # sensor for indicating detected rotation on second elecricity meter during calibration mode
+    rotation_indicator:
+      name: Umdrehungsindikator 2
+  # sensor for wireless connection status
+  - platform: status
+    name: Status
+
+# text sensors
+text_sensor:
+  - platform: wifi_info
+    # sensor providing the IP address of the ESP microcontroller
+    ip_address:
+      name: IP Adresse
+
+# number components
+number:
+  # import entity holding last energy meter reading of first elecricity meter from Home Assistant
+  - platform: homeassistant
+    id: last_energy_value_1
+    entity_id: input_number.stromzaehler_1_letzter_wert
+  # import entity holding last energy meter reading of second elecricity meter from Home Assistant
+  - platform: homeassistant
+    id: last_energy_value_2
+    entity_id: input_number.stromzaehler_2_letzter_wert
+  # number used to manually overwrite the energy meter of first electricity meter
+  - platform: template
+    id: target_energy_value_1
+    name: Manueller Zählerstand 1
+    icon: mdi:counter
+    unit_of_measurement: kWh
+    device_class: energy
+    entity_category: config
+    mode: box
+    optimistic: true
+    min_value: 0
+    max_value: 1000000
+    step: 0.01
+  # number used to manually overwrite the energy meter of second electricity meter
+  - platform: template
+    id: target_energy_value_2
+    name: Manueller Zählerstand 2
+    icon: mdi:counter
+    unit_of_measurement: kWh
+    device_class: energy
+    entity_category: config
+    mode: box
+    optimistic: true
+    min_value: 0
+    max_value: 1000000
+    step: 0.01
+
+# switch components
+switch:
+  - platform: ferraris
+    ferraris_id: ferraris_meter_1
+    # switch used to activate or deactivate the calibration mode for first electricity meter
+    calibration_mode:
+      name: Kalibrierungsmodus 1
+  - platform: ferraris
+    ferraris_id: ferraris_meter_2
+    # switch used to activate or deactivate the calibration mode for second electricity meter
+    calibration_mode:
+      name: Kalibrierungsmodus 2
+
+# button components
+button:
+  # button used to trigger the manual overwriting of the energy meter of first electricity meter
+  - platform: template
+    name: Verbrauchszähler 1 überschreiben
+    icon: mdi:download
+    entity_category: config
+    on_press:
+      - ferraris.set_energy_meter:
+          id: ferraris_meter_1
+          value: !lambda |-
+            float val = id(target_energy_value_1).state;
+            return (val >= 0) ? val : 0;
+  # button used to trigger the manual overwriting of the energy meter of second electricity meter
+  - platform: template
+    name: Verbrauchszähler 2 überschreiben
+    icon: mdi:download
+    entity_category: config
+    on_press:
+      - ferraris.set_energy_meter:
+          id: ferraris_meter_2
+          value: !lambda |-
+            float val = id(target_energy_value_2).state;
+            return (val >= 0) ? val : 0;


### PR DESCRIPTION
This pull request adds an example configuration describing how to configure the firmware in order to read multiple Ferraris electricity meters with a single ESP microcontroller.

It also adds a small correction to the default example configuration.

Resolves #22