### PR TITLE
Improve restoring of energy meter at boot

### DIFF
--- a/components/ferraris/ferraris_meter.cpp
+++ b/components/ferraris/ferraris_meter.cpp
@@ -80,17 +80,17 @@ namespace esphome::ferraris
 
         if (m_energy_start_value_number != nullptr)
         {
-            m_energy_start_value_number->add_on_state_callback([this](float value)
+            if (m_energy_start_value_number->has_state())
             {
-                if (!m_start_value_received)
+                restore_energy_meter(m_energy_start_value_number->state);
+            }
+            else
+            {
+                m_energy_start_value_number->add_on_state_callback([this](float value)
                 {
-                    m_rotation_counter = static_cast<uint64_t>(value / 1000 * m_rotations_per_kwh);
-                    ESP_LOGD(TAG, "Restored rotation counter:  %u rotations", m_rotation_counter);
-
-                    m_start_value_received = true;
-                    update_energy_counter();
-                }
-            });
+                    restore_energy_meter(value);
+                });
+            }
         }
         else
         {
@@ -188,6 +188,18 @@ namespace esphome::ferraris
                     mode ? m_last_state : false);
         }
 #endif
+    }
+
+    void FerrarisMeter::restore_energy_meter(float value)
+    {
+        if (!m_start_value_received)
+        {
+            m_rotation_counter = static_cast<uint64_t>(value / 1000 * m_rotations_per_kwh);
+            ESP_LOGD(TAG, "Restored rotation counter:  %u rotations", m_rotation_counter);
+
+            m_start_value_received = true;
+            update_energy_counter();
+        }
     }
 
     void FerrarisMeter::set_energy_meter(float value)

--- a/components/ferraris/ferraris_meter.h
+++ b/components/ferraris/ferraris_meter.h
@@ -58,7 +58,7 @@ namespace esphome::ferraris
         void dump_config() override;
 
         void set_calibration_mode(bool mode);
-
+        void restore_energy_meter(float value);
         void set_energy_meter(float value);
         void set_rotation_counter(uint64_t value);
 


### PR DESCRIPTION
This pull request improves the restoring of the energy meter at boot by checking first if the `last_energy_value` number component already has a value and only if not registering a callback for state changes of that component.

Fixes #24