### PR TITLE
Rename low_state_threshold to debounce_threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Die folgenden Abschnitte beschreiben die wichtigsten Komponenten, die in der Fir
 ### Ferraris-Komponente
 Die Komponente Ferraris ist unabdingbar und muss hinzugefügt werden, um ihre Sensoren zu verwenden.
 
-Da es sich um eine individuelle Komponente handelt, die nicht Teil von ESPHome ist, muss sie explizit importiert werden. Am einfachsten ist es, die Komponente direkt aus diesem Repository zu laden.
+Da es sich um eine benutzerdefinierte Komponente handelt, die nicht Teil von ESPHome ist, muss sie explizit importiert werden. Am einfachsten ist es, die Komponente direkt aus diesem Repository zu laden.
 
 ##### Beispiel
 
@@ -65,16 +65,18 @@ Die folgenden generischen Einstellungen können konfiguriert werden:
 | `id` | nein <sup>1</sup> | - | ID der Instanz der Ferraris-Komponente |
 | `pin` | ja <sup>2</sup> | - | ID des GPIO-Pins, mit dem der digitale Ausgang des TCRT5000-Moduls verbunden ist |
 | `analog_input` | ja <sup>2</sup> | - | ID eines [ADC-Sensors](https://www.esphome.io/components/sensor/adc.html), der den mit dem analogen Ausgang des TCRT5000-Moduls verbundenen Pin ausliest |
-| `analog_threshold` | nein | 500 | ID einer [Zahlen-Komponente](https://www.esphome.io/components/number), deren Wert als Schwellwert für die Erkennung einer Umdrehung über den analogen Eingang dient oder ein Schwellwert als feste Zahl |
+| `analog_threshold` | nein | 500 | ID einer [Zahlen-Komponente](https://www.esphome.io/components/number), deren Wert als Schwellwert für die Erkennung einer Umdrehung über den analogen Eingang dient oder ein Schwellwert als feste Zahl <sup>3</sup> |
 | `rotations_per_kwh` | nein | 75 | Anzahl der Umdrehungen der Drehscheibe pro kWh (der Wert ist i.d.R. auf dem Ferraris-Stromzähler vermerkt) |
-| `low_state_threshold` | nein | 400 | Minimale Zeit in Millisekunden zwischen fallender und darauffolgender steigender Flanke, damit die Umdrehung berücksichtigt wird <sup>3</sup> |
+| `debounce_threshold` | nein | 400 | Minimale Zeit in Millisekunden zwischen fallender und darauffolgender steigender Flanke, damit die Umdrehung berücksichtigt wird <sup>4</sup> |
 | `energy_start_value` | nein | - | ID einer [Zahlen-Komponente](https://www.esphome.io/components/number), deren Wert beim Booten als Startwert für den Verbrauchszähler verwendet wird |
 
 <sup>1</sup> Bestimmte Anwendungsfälle benötigen das Konfigurationselement `id`.
 
 <sup>2</sup> Nur eines der beiden Konfigurationselemente `pin` und `analog_input` wird benötigt, je nach Hardware-Aufbauvariante.
 
-<sup>3</sup> Der Übergang von nicht markiertem zu markiertem Bereich und umgekehrt auf der Drehscheibe kann zu einem schnellen Hin-und Herspringen des Erkennungszustands des Sensors führen, das vor allem bei langsamen Drehgeschwindigkeiten auftritt und nicht vollständig durch die Kalibierung unterdrückt werden kann. Diese schnellen Wechsel führen zu verfälschten Messwerten und um diese zu vermeiden, gibt es die Einstellung `low_state_threshold`, welche die minimale Zeit in Millisekunden zwischen fallender und darauffolgender steigender Flanke angibt. Nur wenn die gemessene Zeit zwischen den zwei Flanken über dem konfigurierten Wert liegt, wird die Sensorauslösung berücksichtigt.
+<sup>3</sup> Der Schwellwert steuert, wann das analoge Signal als "erkannt" (markierter Bereich der Drehscheibe) und wann als "nicht erkannt" (nicht markierter Bereich der Drehscheibe) behandelt wird. Ist der Wert aus dem ADC-Sensor größer als der Schwellwert, gilt die Markierung als erkannt, ist er kleiner, gilt sie als nicht erkannt.
+
+<sup>4</sup> Der Übergang von nicht markiertem zu markiertem Bereich und umgekehrt auf der Drehscheibe kann zu einem schnellen Hin-und Herspringen ("prellen") des Erkennungszustands des Sensors führen, das vor allem bei langsamen Drehgeschwindigkeiten auftritt und nicht vollständig durch die Kalibierung unterdrückt werden kann. Dieses Prellen führt zu verfälschten Messwerten und um diese zu vermeiden, gibt es die Einstellung `debounce_threshold` (Entprellungsschwellwert), welche die minimale Zeit in Millisekunden zwischen fallender und darauffolgender steigender Flanke angibt. Nur wenn die gemessene Zeit zwischen den zwei Flanken über dem konfigurierten Wert liegt, wird die Sensorauslösung berücksichtigt.
 
 ##### Beispiel
 ```yaml
@@ -82,7 +84,7 @@ ferraris:
   id: ferraris_meter
   pin: GPIO4
   rotations_per_kwh: 75
-  low_state_threshold: 400
+  debounce_threshold: 400
   energy_start_value: last_energy_value
 ```
 
@@ -529,16 +531,18 @@ The following generic configuration items can be configured:
 | `id` | no <sup>1</sup> | - | ID of the Ferraris component instance |
 | `pin` | yes <sup>2</sup> | - | ID of the GPIO pin to which the digital output of the TCRT5000 module is connected |
 | `analog_input` | yes <sup>2</sup> | - | ID of an [ADC sensor](https://www.esphome.io/components/sensor/adc.html) which reads out the pin connected to the analog output of the TCRT5000 module |
-| `analog_threshold` | no | 500 | ID of a [number component](https://www.esphome.io/components/number) whose value is used as threshold value for the detection of rotations via the analog input or a fixed number as threshold |
+| `analog_threshold` | no | 500 | ID of a [number component](https://www.esphome.io/components/number) whose value is used as threshold value for the detection of rotations via the analog input or a fixed number as threshold <sup>3</sup> |
 | `rotations_per_kwh` | no | 75 | Number of rotations of the turntable per kWh (that value is usually noted on the Ferraris electricity meter) |
-| `low_state_threshold` | no | 400 | Minimum time in milliseconds between falling and subsequent rising edge to take the rotation into account <sup>3</sup> |
+| `debounce_threshold` | no | 400 | Minimum time in milliseconds between falling and subsequent rising edge to take the rotation into account <sup>4</sup> |
 | `energy_start_value` | no | - | ID of a [number component](https://www.esphome.io/components/number), whose value will be used as starting value for the energy counter at boot time |
 
 <sup>1</sup> Some use cases require the configuration element `id`.
 
 <sup>2</sup> Only one of `pin` or `analog_input` is required, depending on the hardware setup variant.
 
-<sup>3</sup> The transition from unmarked to marked area and vice versa on the turntable can lead to a rapid back and forth jump in the detection state of the sensor, which occurs particularly at slow rotation speeds and cannot be completely suppressed by the calibration. These rapid changes lead to falsified measured values and to avoid this, there is the setting `low_state_threshold`, which specifies the minimum time in milliseconds between falling and subsequent rising edge. The trigger from the sensor is only taken into account if the measured time between the two edges is above the configured value.
+<sup>3</sup> The threshold value controls when the analog signal is treated as "detected" (marked area of the turntable) and when it is treated as "not detected" (unmarked area of the turntable). If the value from the ADC sensor is greater than the threshold value, the marking is considered detected; if it is smaller, it is considered not detected.
+
+<sup>4</sup> The transition from unmarked to marked area and vice versa on the turntable can lead to a rapid back and forth jump ("bouncing") in the detection state of the sensor, which occurs particularly at slow rotation speeds and cannot be completely suppressed by the calibration. This bouncing of the state leads to falsified measured values and to avoid this, there is the setting `debounce_threshold`, which specifies the minimum time in milliseconds between falling and subsequent rising edge. The trigger from the sensor is only taken into account if the measured time between the two edges is above the configured value.
 
 ##### Example
 ```yaml
@@ -546,7 +550,7 @@ ferraris:
   id: ferraris_meter
   pin: GPIO4
   rotations_per_kwh: 75
-  low_state_threshold: 400
+  debounce_threshold: 400
   energy_start_value: last_energy_value
 ```
 

--- a/components/ferraris/__init__.py
+++ b/components/ferraris/__init__.py
@@ -37,12 +37,12 @@ from esphome.const       import (
 CODEOWNERS = ["@jensrossbach"]
 MULTI_CONF = True
 
-CONF_FERRARIS_ID         = "ferraris_id"
-CONF_ANALOG_INPUT        = "analog_input"
-CONF_ANALOG_THRESHOLD    = "analog_threshold"
-CONF_ROTATIONS_PER_KWH   = "rotations_per_kwh"
-CONF_LOW_STATE_THRESHOLD = "low_state_threshold"
-CONF_ENERGY_START_VALUE  = "energy_start_value"
+CONF_FERRARIS_ID        = "ferraris_id"
+CONF_ANALOG_INPUT       = "analog_input"
+CONF_ANALOG_THRESHOLD   = "analog_threshold"
+CONF_ROTATIONS_PER_KWH  = "rotations_per_kwh"
+CONF_DEBOUNCE_THRESHOLD = "debounce_threshold"
+CONF_ENERGY_START_VALUE = "energy_start_value"
 
 ferraris_ns = cg.esphome_ns.namespace("ferraris")
 FerrarisMeter = ferraris_ns.class_("FerrarisMeter", cg.Component)
@@ -63,7 +63,7 @@ CONFIG_SCHEMA = cv.All(
         cv.Optional(CONF_ANALOG_INPUT): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_ANALOG_THRESHOLD, default = 500): cv.Any(cv.Coerce(float), cv.use_id(number.Number)),
         cv.Optional(CONF_ROTATIONS_PER_KWH, default = 75): cv.int_range(min = 1),
-        cv.Optional(CONF_LOW_STATE_THRESHOLD, default = 400): cv.int_range(min = 0),
+        cv.Optional(CONF_DEBOUNCE_THRESHOLD, default = 400): cv.int_range(min = 0),
         cv.Optional(CONF_ENERGY_START_VALUE): cv.use_id(number.Number)
     }).extend(cv.COMPONENT_SCHEMA),
     ensure_pin_or_adc)
@@ -73,7 +73,7 @@ async def to_code(config):
     cmp = cg.new_Pvariable(
                 config[CONF_ID],
                 config[CONF_ROTATIONS_PER_KWH],
-                config[CONF_LOW_STATE_THRESHOLD])
+                config[CONF_DEBOUNCE_THRESHOLD])
     await cg.register_component(cmp, config)
 
     if CONF_PIN in config:

--- a/components/ferraris/ferraris_meter.cpp
+++ b/components/ferraris/ferraris_meter.cpp
@@ -37,7 +37,7 @@ namespace esphome::ferraris
 
     static constexpr const char *const TAG = "ferraris";
 
-    FerrarisMeter::FerrarisMeter(uint32_t rpkwh, uint32_t low_state_threshold)
+    FerrarisMeter::FerrarisMeter(uint32_t rpkwh, uint32_t debounce_threshold)
         : Component()
         , m_pin(nullptr)
 #ifdef USE_SENSOR
@@ -57,7 +57,7 @@ namespace esphome::ferraris
 #endif
         , m_analog_input_threshold(0.0f)
         , m_rotations_per_kwh(rpkwh)
-        , m_low_state_threshold(low_state_threshold)
+        , m_debounce_threshold(debounce_threshold)
         , m_last_state(false)
         , m_last_time(-1)
         , m_last_rising_time(-1)
@@ -152,7 +152,7 @@ namespace esphome::ferraris
 #endif
 #endif
         ESP_LOGCONFIG(TAG, "  Rotations per kWh: %d", m_rotations_per_kwh);
-        ESP_LOGCONFIG(TAG, "  Low state threshold: %d ms", m_low_state_threshold);
+        ESP_LOGCONFIG(TAG, "  Debounce threshold: %d ms", m_debounce_threshold);
 #ifdef USE_SENSOR
         LOG_SENSOR("", "Power consumption sensor", m_power_consumption_sensor);
         LOG_SENSOR("", "Energy meter sensor", m_energy_meter_sensor);
@@ -192,11 +192,11 @@ namespace esphome::ferraris
                     }
                     else
                     {
-                        uint32_t low_state_duration = get_duration(m_last_time, now);
+                        uint32_t falling_to_rising_duration = get_duration(m_last_time, now);
 
-                        if (low_state_duration < m_low_state_threshold)
+                        if (falling_to_rising_duration < m_debounce_threshold)
                         {
-                            ESP_LOGD(TAG, "Ignoring low state duration below threshold:  %u ms", low_state_duration);
+                            ESP_LOGD(TAG, "Ignoring falling to rising duration below threshold:  %u ms", falling_to_rising_duration);
                         }
                         else
                         {

--- a/components/ferraris/ferraris_meter.h
+++ b/components/ferraris/ferraris_meter.h
@@ -49,7 +49,7 @@ namespace esphome::ferraris
     class FerrarisMeter : public Component
     {
     public:
-        FerrarisMeter(uint32_t rpkwh, uint32_t low_state_threshold);
+        FerrarisMeter(uint32_t rpkwh, uint32_t debounce_threshold);
         virtual ~FerrarisMeter() = default;
 
         void setup() override;
@@ -155,7 +155,7 @@ namespace esphome::ferraris
 
         float m_analog_input_threshold;
         uint32_t m_rotations_per_kwh;
-        uint32_t m_low_state_threshold;
+        uint32_t m_debounce_threshold;
 
         bool m_last_state;
         int64_t m_last_time;


### PR DESCRIPTION
### ‼️ Breaking Changes ‼️
If the YAML configuration file contains the element `low_state_threshold`, it must be adapted, otherwise an error will occur during compilation of the ESPHome firmware.

----------

This pull request renames the configuration element `low_state_threshold` to `debounce_threshold` in order to make the name clearer and to distinguish it better from the `analog_threshold` element.