### PR TITLE
Restrict hysteresis offsets to positive values

### DIFF
--- a/components/ferraris/__init__.py
+++ b/components/ferraris/__init__.py
@@ -64,8 +64,8 @@ CONFIG_SCHEMA = cv.All(
         cv.Optional(CONF_PIN): pins.internal_gpio_input_pin_schema,
         cv.Optional(CONF_ANALOG_INPUT): cv.use_id(sensor.Sensor),
         cv.Optional(CONF_ANALOG_THRESHOLD, default = 50): cv.Any(cv.Coerce(float), cv.use_id(number.Number)),
-        cv.Optional(CONF_OFF_TOLERANCE, default = 0): cv.Any(cv.Coerce(float), cv.use_id(number.Number)),
-        cv.Optional(CONF_ON_TOLERANCE, default = 0): cv.Any(cv.Coerce(float), cv.use_id(number.Number)),
+        cv.Optional(CONF_OFF_TOLERANCE, default = 0): cv.Any(cv.All(cv.positive_float, cv.Coerce(float)), cv.use_id(number.Number)),
+        cv.Optional(CONF_ON_TOLERANCE, default = 0): cv.Any(cv.All(cv.positive_float, cv.Coerce(float)), cv.use_id(number.Number)),
         cv.Optional(CONF_ROTATIONS_PER_KWH, default = 75): cv.int_range(min = 1),
         cv.Optional(CONF_DEBOUNCE_THRESHOLD, default = 400): cv.Any(cv.int_range(min = 0), cv.use_id(number.Number)),
         cv.Optional(CONF_ENERGY_START_VALUE): cv.use_id(number.Number)


### PR DESCRIPTION
This pull request restricts the configuration items `off_tolerance` and `on_tolerance` to positive values (in case the values are provided as static numbers) because negative values do not make sense. However, the use of number components which allow negative values cannot be prevented unfortunately.

Resolves #41