### PR TITLE
Automatic calibration of analog signal from infrared sensor

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Jens-Uwe Rossbach
+Copyright (c) 2024-2025 Jens-Uwe Rossbach
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/components/ferraris/automation.h
+++ b/components/ferraris/automation.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Jens-Uwe Rossbach
+ * Copyright (c) 2024-2025 Jens-Uwe Rossbach
  *
  * This code is licensed under the MIT License.
  *
@@ -77,5 +77,35 @@ namespace esphome::ferraris
     protected:
         FerrarisMeter *m_ferraris_meter;
         TemplatableValue<uint64_t, Ts...> m_rotation_counter_value;
+    };
+
+    template<typename... Ts> class StartAnalogCalibrationAction : public Action<Ts...>
+    {
+    public:
+        StartAnalogCalibrationAction(
+                FerrarisMeter *ferraris_meter,
+                uint32_t num_captured_values,
+                float min_level_dist,
+                uint8_t max_iterations)
+            : m_ferraris_meter(ferraris_meter)
+            , m_num_captured_values(num_captured_values)
+            , m_min_level_distance(min_level_dist)
+            , m_max_iterations(max_iterations)
+        {
+        }
+
+        void play(Ts... x) override
+        {
+            m_ferraris_meter->start_analog_calibration(
+                                    m_num_captured_values,
+                                    m_min_level_distance,
+                                    m_max_iterations);
+        }
+
+    protected:
+        FerrarisMeter *m_ferraris_meter;
+        uint32_t m_num_captured_values;
+        float m_min_level_distance;
+        uint8_t m_max_iterations;
     };
 }  // namespace esphome::ferraris

--- a/components/ferraris/ferraris_meter.h
+++ b/components/ferraris/ferraris_meter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Jens-Uwe Rossbach
+ * Copyright (c) 2024-2025 Jens-Uwe Rossbach
  *
  * This code is licensed under the MIT License.
  *
@@ -62,6 +62,19 @@ namespace esphome::ferraris
         void restore_energy_meter(float value);
         void set_energy_meter(float value);
         void set_rotation_counter(uint64_t value);
+
+        void start_analog_calibration(
+                uint32_t num_captured_values,
+                float min_level_dist,
+                uint8_t max_iterations)
+        {
+            m_num_captured_values = num_captured_values;
+            m_min_level_distance = min_level_dist;
+            m_max_iterations = max_iterations;
+
+            m_level_value_counter = 0;
+            m_iteration_counter = 0;
+        }
 
 #ifdef USE_SENSOR
         void set_digital_input_pin(InternalGPIOPin *pin)
@@ -198,6 +211,14 @@ namespace esphome::ferraris
         int64_t m_last_time;
         int64_t m_last_rising_time;
         uint64_t m_rotation_counter;
+
+        float m_off_level;
+        float m_on_level;
+        uint32_t m_num_captured_values;
+        float m_min_level_distance;
+        uint8_t m_max_iterations;
+        uint8_t m_iteration_counter;
+        uint32_t m_level_value_counter;
 
         bool m_calibration_mode;
         bool m_start_value_received;

--- a/example_config/ferraris_meter_analog.yaml
+++ b/example_config/ferraris_meter_analog.yaml
@@ -147,3 +147,14 @@ button:
           value: !lambda |-
             float val = id(target_energy_value).state;
             return (val >= 0) ? val : 0;
+  # button used to trigger automatic calibration of analog signal from infrared sensor
+  - platform: template
+    name: Auto-Kalibrierung starten
+    icon: mdi:auto-fix
+    entity_category: config
+    on_press:
+      - ferraris.start_analog_calibration:
+          id: ferraris_meter
+          num_captured_values: 6000
+          min_level_distance: 6.0
+          max_iterations: 3


### PR DESCRIPTION
This pull request introduces an algorithm that automatically calibrates the analog signal of the infrared sensor by analyzing the analog values provided by the sensor, determining the value range and calculating the analog threshold value via arithmetic mean. This automatic calibration can be triggered on demand via an action or automatically on boot of the microcontroller.

Resolves #57