### PR TITLE
Increase maximum possible iterations for automatic analog calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ Alle Parameter sind optional und können weggelassen werden.
 | --------- | --- | ------- | -------- | ------------ |
 | `num_captured_values` | `uint32` | 100&nbsp;...&nbsp;100000 | 6000 | Anzahl der zu erfassenden analogen Werte pro Kalibrierungsdurchlauf |
 | `min_level_distance` | `float` | >=&nbsp;0 | 6.0 | Mindestdifferenz zwischen niedrigstem und höchstem Analogwert, damit die Kalibrierung als erfolgreich angesehen und der analoge Schwellwert gesetzt wird |
-| `max_iterations` | `uint8` | 1&nbsp;...&nbsp;10 | 3 | Maximale Anzahl fehlgeschlagener Kalibrierungsdurchläufe, bevor aufgegeben wird |
+| `max_iterations` | `uint16` | 1&nbsp;...&nbsp;10000 | 3 | Maximale Anzahl fehlgeschlagener Kalibrierungsdurchläufe, bevor aufgegeben wird |
 
 ## Anwendungsbeispiele
 In diesem Abschnitt sind verschiedene Anwendungsbeispiele für die Ferraris-Plattform beschrieben.
@@ -1001,7 +1001,7 @@ All parameters are optional and can be omitted.
 | --------- | ---- | ----- | ------- | ----------- |
 | `num_captured_values` | `uint32` | 100&nbsp;...&nbsp;100000 | 6000 | Number of analog values to capture per calibration iteration |
 | `min_level_distance` | `float` | >=&nbsp;0 | 6.0 | Minimum difference between lowest and highest analog value to accept the calibration and set the analog threshold |
-| `max_iterations` | `uint8` | 1&nbsp;...&nbsp;10 | 3 | Maximum number of failed calibration iterations before giving up |
+| `max_iterations` | `uint16` | 1&nbsp;...&nbsp;10000 | 3 | Maximum number of failed calibration iterations before giving up |
 
 ## Usage Examples
 This section describes various examples of usage for the Ferraris platform.

--- a/components/ferraris/__init__.py
+++ b/components/ferraris/__init__.py
@@ -71,7 +71,7 @@ def ensure_gpio_or_adc(value):
 ANALOG_CALIBRATION_SCHEMA = cv.Schema({
         cv.Optional(CONF_NUM_CAPTURED_VALUES, default = 6000): cv.int_range(min=100, max=100000),
         cv.Optional(CONF_MIN_LEVEL_DISTANCE, default = 6.0): cv.positive_float,
-        cv.Optional(CONF_MAX_ITERATIONS, default = 3): cv.int_range(min=1, max=10)})
+        cv.Optional(CONF_MAX_ITERATIONS, default = 3): cv.int_range(min=1, max=10000)})
 
 CONFIG_SCHEMA = cv.All(
     cv.Schema({

--- a/components/ferraris/automation.h
+++ b/components/ferraris/automation.h
@@ -86,7 +86,7 @@ namespace esphome::ferraris
                 FerrarisMeter *ferraris_meter,
                 uint32_t num_captured_values,
                 float min_level_dist,
-                uint8_t max_iterations)
+                uint16_t max_iterations)
             : m_ferraris_meter(ferraris_meter)
             , m_num_captured_values(num_captured_values)
             , m_min_level_distance(min_level_dist)
@@ -106,6 +106,6 @@ namespace esphome::ferraris
         FerrarisMeter *m_ferraris_meter;
         uint32_t m_num_captured_values;
         float m_min_level_distance;
-        uint8_t m_max_iterations;
+        uint16_t m_max_iterations;
     };
 }  // namespace esphome::ferraris

--- a/components/ferraris/ferraris_meter.h
+++ b/components/ferraris/ferraris_meter.h
@@ -66,7 +66,7 @@ namespace esphome::ferraris
         void start_analog_calibration(
                 uint32_t num_captured_values,
                 float min_level_dist,
-                uint8_t max_iterations)
+                uint16_t max_iterations)
         {
             m_num_captured_values = num_captured_values;
             m_min_level_distance = min_level_dist;
@@ -235,8 +235,8 @@ namespace esphome::ferraris
         float m_on_level;
         uint32_t m_num_captured_values;
         float m_min_level_distance;
-        uint8_t m_max_iterations;
-        uint8_t m_iteration_counter;
+        uint16_t m_max_iterations;
+        uint16_t m_iteration_counter;
         uint32_t m_level_value_counter;
 
         bool m_calibration_mode;


### PR DESCRIPTION
Increases the maximum possible number of iterations for automatic analog calibration from 10 to 10000.