### PR TITLE
Improving Ferraris Meter accuracy when power drawing decreases

### DIFF
--- a/components/ferraris/__init__.py
+++ b/components/ferraris/__init__.py
@@ -37,10 +37,11 @@ CODEOWNERS = ["@jensrossbach"]
 MULTI_CONF = True
 
 # common
-CONF_FERRARIS_ID         = "ferraris_id"
-CONF_ROTATIONS_PER_KWH   = "rotations_per_kwh"
-CONF_DEBOUNCE_THRESHOLD  = "debounce_threshold"
-CONF_ENERGY_START_VALUE  = "energy_start_value"
+CONF_FERRARIS_ID            = "ferraris_id"
+CONF_ROTATIONS_PER_KWH      = "rotations_per_kwh"
+CONF_INTERPOLATION_INTERVAL = "interpolation_interval"
+CONF_DEBOUNCE_THRESHOLD     = "debounce_threshold"
+CONF_ENERGY_START_VALUE     = "energy_start_value"
 
 # digital input
 CONF_DIGITAL_INPUT       = "digital_input"
@@ -82,6 +83,7 @@ CONFIG_SCHEMA = cv.All(
         cv.Optional(CONF_OFF_TOLERANCE, default = 0): cv.Any(cv.All(cv.positive_float, cv.Coerce(float)), cv.use_id(number.Number)),
         cv.Optional(CONF_ON_TOLERANCE, default = 0): cv.Any(cv.All(cv.positive_float, cv.Coerce(float)), cv.use_id(number.Number)),
         cv.Optional(CONF_ROTATIONS_PER_KWH, default = 75): cv.int_range(min = 1),
+        cv.Optional(CONF_INTERPOLATION_INTERVAL, default = 10): cv.int_range(min = 0, max = 60),
         cv.Optional(CONF_DEBOUNCE_THRESHOLD, default = 400): cv.Any(cv.int_range(min = 0), cv.use_id(number.Number)),
         cv.Optional(CONF_ENERGY_START_VALUE): cv.use_id(number.Number),
         cv.Optional(CONF_CALIBRATE_ON_BOOT): ANALOG_CALIBRATION_SCHEMA
@@ -92,7 +94,8 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     cmp = cg.new_Pvariable(
                 config[CONF_ID],
-                config[CONF_ROTATIONS_PER_KWH])
+                config[CONF_ROTATIONS_PER_KWH],
+                config[CONF_INTERPOLATION_INTERVAL])
     await cg.register_component(cmp, config)
 
     if CONF_DIGITAL_INPUT in config:

--- a/components/ferraris/ferraris_meter.cpp
+++ b/components/ferraris/ferraris_meter.cpp
@@ -31,13 +31,14 @@
 
 namespace esphome::ferraris
 {
-    static constexpr const uint32_t WATTS_PER_KW = 1000;
-    static constexpr const uint32_t MS_PER_HOUR  = 60 * 60 * 1000;
-    static constexpr const uint32_t KWH_TO_WMS   = WATTS_PER_KW * MS_PER_HOUR;
+    static constexpr uint32_t WATTS_PER_KW  = 1000u;
+    static constexpr uint32_t MS_PER_SECOND = 1000u;
+    static constexpr uint32_t MS_PER_HOUR   = 60u * 60u * 1000u;
+    static constexpr uint32_t KWH_TO_WMS    = WATTS_PER_KW * MS_PER_HOUR;
 
     static constexpr const char *const TAG = "ferraris";
 
-    FerrarisMeter::FerrarisMeter(uint32_t rpkwh)
+    FerrarisMeter::FerrarisMeter(uint32_t rpkwh, uint16_t intIv)
         : Component()
         , m_digital_input_pin(nullptr)
 #ifdef USE_SENSOR
@@ -65,17 +66,21 @@ namespace esphome::ferraris
         , m_off_tolerance(0.0f)
         , m_on_tolerance(0.0f)
         , m_rotations_per_kwh(rpkwh)
+        , m_interpolation_interval(intIv * MS_PER_SECOND)
         , m_debounce_threshold(0)
         , m_last_state(false)
         , m_last_time(-1)
         , m_last_rising_time(-1)
-        , m_rotation_counter(0)
-        , m_off_level(0.0)
-        , m_on_level(0.0)
-        , m_num_captured_values(6000)
-        , m_min_level_distance(6.0)
-        , m_max_iterations(3)
-        , m_iteration_counter(0)
+        , m_interpolation_start(-1)
+        , m_rotation_counter(0u)
+        , m_last_rotation_time(std::numeric_limits<uint32_t>::max())
+        , m_acc_rotation_time(0u)
+        , m_off_level(0.0f)
+        , m_on_level(0.0f)
+        , m_num_captured_values(6000u)
+        , m_min_level_distance(6.0f)
+        , m_max_iterations(3u)
+        , m_iteration_counter(0u)
         , m_level_value_counter(m_num_captured_values)
         , m_calibration_mode(false)
         , m_start_value_received(false)
@@ -286,6 +291,24 @@ namespace esphome::ferraris
         {
             handle_state(m_digital_input_pin->digital_read());
         }
+
+        if ((m_interpolation_interval > 0u) && (m_interpolation_start >= 0u))
+        {
+            uint32_t now = millis();
+
+            if (get_duration(m_interpolation_start, now) >= m_interpolation_interval)
+            {
+                m_acc_rotation_time += m_interpolation_interval;
+                ESP_LOGD(TAG, "Accumulated rotation time:  %u ms", m_acc_rotation_time);
+
+                if (m_acc_rotation_time > m_last_rotation_time)
+                {
+                    update_power_consumption(m_acc_rotation_time);
+                }
+
+                m_interpolation_start = now;
+            }
+        }
     }
 
     void FerrarisMeter::dump_config()
@@ -321,7 +344,8 @@ namespace esphome::ferraris
         }
 #endif
 #endif
-        ESP_LOGCONFIG(TAG, "  Rotations per kWh: %d", m_rotations_per_kwh);
+        ESP_LOGCONFIG(TAG, "  Rotations per kWh: %u", m_rotations_per_kwh);
+        ESP_LOGCONFIG(TAG, "  Interpolation interval: %u", m_interpolation_interval);
 #ifdef USE_NUMBER
         if (m_debounce_threshold_number == nullptr)
         {
@@ -349,7 +373,7 @@ namespace esphome::ferraris
     {
         if (state != m_last_state)
         {
-            ESP_LOGD(TAG, "State change:  %d -> %d", m_last_state, state);
+            ESP_LOGD(TAG, "State change:  %u -> %u", m_last_state, state);
 
             if (m_calibration_mode)
             {
@@ -384,13 +408,16 @@ namespace esphome::ferraris
 
                             ESP_LOGD(TAG, "Rotation time:  %u ms", rotation_time);
 
-                            m_rotation_counter++;
+                            ++m_rotation_counter;
                             ESP_LOGD(TAG, "Updated rotation counter:  %llu rotations", m_rotation_counter);
 
                             update_power_consumption(rotation_time);
                             update_energy_counter();
 
                             m_last_rising_time = now;
+                            m_last_rotation_time = rotation_time;
+                            m_acc_rotation_time = 0;
+                            m_interpolation_start = now;
                         }
                     }
                 }

--- a/components/ferraris/ferraris_meter.h
+++ b/components/ferraris/ferraris_meter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024-2025 Jens-Uwe Rossbach
+ * Copyright (c) 2024-2026 Jens-Uwe Rossbach
  *
  * This code is licensed under the MIT License.
  *
@@ -49,7 +49,7 @@ namespace esphome::ferraris
     class FerrarisMeter : public Component
     {
     public:
-        FerrarisMeter(uint32_t rpkwh);
+        FerrarisMeter(uint32_t rpkwh, uint16_t intIv);
         virtual ~FerrarisMeter() = default;
 
         void setup() override;
@@ -180,17 +180,17 @@ namespace esphome::ferraris
         void update_energy_counter();
         void set_analog_calibration_state(bool running, float range = 0, bool problem = false);
 
-        static inline uint32_t get_duration(uint32_t time1, uint32_t time2)
+        static inline uint32_t get_duration(uint32_t start, uint32_t end)
         {
             uint32_t ret = 0;
 
-            if (time2 < time1)  // overflow after ~50 days
+            if (end < start)  // overflow after ~50 days
             {
-                ret = std::numeric_limits<uint32_t>::max() - time1 + time2;
+                ret = std::numeric_limits<uint32_t>::max() - start + end;
             }
             else
             {
-                ret = time2 - time1;
+                ret = end - start;
             }
 
             return ret;
@@ -224,12 +224,16 @@ namespace esphome::ferraris
         float m_off_tolerance;
         float m_on_tolerance;
         uint32_t m_rotations_per_kwh;
+        uint32_t m_interpolation_interval;
         uint32_t m_debounce_threshold;
 
         bool m_last_state;
         int64_t m_last_time;
         int64_t m_last_rising_time;
+        int64_t m_interpolation_start;
         uint64_t m_rotation_counter;
+        uint32_t m_last_rotation_time;
+        uint32_t m_acc_rotation_time;
 
         float m_off_level;
         float m_on_level;

--- a/doc/source/documentation/software_setup.rst
+++ b/doc/source/documentation/software_setup.rst
@@ -59,8 +59,13 @@ Die folgenden allgemeinen Einstellungen können konfiguriert werden:
       - nein
       - 75
       - Anzahl der Umdrehungen der Drehscheibe pro kWh (der Wert ist i.d.R. auf dem Ferraris-Stromzähler vermerkt)
+    * - ``interpolation_interval``
+      - Zahl
+      - nein
+      - 10
+      - Dauer des Interpolationsintervalls in Sekunden, ``0``, um die Interpolation auszuschalten; siehe Abschnitt :ref:`Interpolation bei fallenden Stromverbräuchen <power-interpolation>` für Details
     * - ``debounce_threshold``
-      - Zahl |nbsp| / |nbsp| `ID <https://www.esphome.io/guides/configuration-types#config-id>`_ |nbsp| [#fn3]_
+      - Zahl |nbsp| / |nbsp| `ID <https://www.esphome.io/guides/configuration-types#config-id>`_ |nbsp| [#fn2]_
       - nein
       - 400
       - Minimale Zeit in Millisekunden zwischen fallender und darauffolgender steigender Flanke, damit die Umdrehung berücksichtigt wird; siehe Abschnitt :ref:`Entprellungsschwellwert <debounce-threshold>` für Details
@@ -82,7 +87,7 @@ Die folgenden Einstellungen sind nur relevant, wenn der digitale Ausgang des Inf
       - Beschreibung
     * - ``digital_input``
       - `Pin <https://www.esphome.io/guides/configuration-types#pin>`_
-      - ja [#fn2]_
+      - ja [#fn3]_
       - \-
       - GPIO-Pin, mit dem der digitale Ausgang des TCRT5000-Moduls verbunden ist
 
@@ -98,7 +103,7 @@ Die folgenden Einstellungen sind nur relevant, wenn der analoge Ausgang des Infr
       - Beschreibung
     * - ``analog_input``
       - `ID <https://www.esphome.io/guides/configuration-types#config-id>`_
-      - ja [#fn2]_
+      - ja [#fn3]_
       - \-
       - `ADC-Sensor <https://www.esphome.io/components/sensor/adc.html>`_, der den mit dem analogen Ausgang des TCRT5000-Moduls verbundenen Pin ausliest
     * - ``analog_threshold``
@@ -139,9 +144,9 @@ Die folgenden Einstellungen können für das Objekt ``calibrate_on_boot`` konfig
 
 .. [#fn1] Bestimmte :ref:`Anwendungsfälle <usage-examples>` benötigen das Konfigurationselement ``id``.
 
-.. [#fn2] Nur eines der beiden Konfigurationselemente - ``digital_input`` oder ``analog_input`` - wird benötigt, je nach :ref:`Hardware-Aufbauvariante <hardware-setup>`.
+.. [#fn2] Die Konfigurationselemente ``analog_threshold``\ , ``off_tolerance``\ , ``on_tolerance`` und ``debounce_threshold`` erwarten entweder eine feste Zahl oder die ID einer `Zahlen-Komponente <https://www.esphome.io/components/number>`_. Letzteres ermöglicht das Konfigurieren des Wertes über das User-Interface (z.B. durch die Verwendung einer `Template-Zahlen-Komponente <https://www.esphome.io/components/number/template.html>`_\ ).
 
-.. [#fn3] Die Konfigurationselemente ``analog_threshold``\ , ``off_tolerance``\ , ``on_tolerance`` und ``debounce_threshold`` erwarten entweder eine feste Zahl oder die ID einer `Zahlen-Komponente <https://www.esphome.io/components/number>`_. Letzteres ermöglicht das Konfigurieren des Wertes über das User-Interface (z.B. durch die Verwendung einer `Template-Zahlen-Komponente <https://www.esphome.io/components/number/template.html>`_\ ).
+.. [#fn3] Nur eines der beiden Konfigurationselemente - ``digital_input`` oder ``analog_input`` - wird benötigt, je nach :ref:`Hardware-Aufbauvariante <hardware-setup>`.
 
 Beispiel
 --------

--- a/doc/source/documentation/usage_examples.rst
+++ b/doc/source/documentation/usage_examples.rst
@@ -441,6 +441,17 @@ Glättung des analogen Signals
 
 Durch eine geschickte Konfiguration des Aktualisierungsintervalls ``update_interval`` und der Anzahl Abtastungen pro Aktualisierung (``samples``) für den analogen Sensor ``analog_input`` kann die Kurve des analogen Signals so weit geglättet werden, dass kurzfristige Schwankungen eliminiert werden. Es ist aber zu bedenken, dass zu große Aktualisierungsintervalle dazu führen können, dass einzelne Umdrehungen bei sehr hohen Drehgeschwindigkeiten nicht mehr erkannt werden, da dann die Zeit zwischen steigender und darauffolgender fallender Flanke kleiner als das eingestellte Aktualisierungsintervall ist. Auch diese Art der Entprellung funktioniert nur bei der Verwendung des analogen Eingangssignals des Infrarotsensors.
 
+.. _power-interpolation:
+
+Interpolation bei fallenden Stromverbräuchen
+============================================
+
+Niedrige Stromverbräuche äußern sich in einer langsamen Geschwindigkeit der Drehscheibe. Dies führt dazu, dass die Markierung auf der Drehscheibe nur selten am Sensor vorbei fährt und dadurch aktualisiert sich der Stromverbrauch ebensfalls nur in großen Zeitabständen. Besonders störend ist dies, wenn ein hoher Stromverbrauch vorliegt und dieser sich dann rasch absenkt. In diesem Fall dauert es sehr lang, bis der neue niedrige Stromverbrauch gemeldet wird, da es lange dauert, bis die Markierung wieder den Sensor passiert. In dieser Zeit wird dann weiterhin ein hoher Stromverbrauch angezeigt, obwohl der tatsächliche Stromverbrauch viel niedriger ist.
+
+Um diesem Effekt entgegenzuwirken, kann die Ferraris-Komponente bei Übergängen von hohen zu niedrigen Stromverbräuchen den tatsächlichen Verbrauchsverlauf interpolieren und sich somit dem tatsächlichen Stromverbrauch immer weiter annähern, bis der tatsächliche Stromverbrauch nach Detektierung der Markierung berechnet und gemeldet wird.
+
+Die Interpolation kann über das Interpolationsintervall ``interpolation_interval`` gesteuert werden. Ein Wert von ``0`` deaktiviert die Interpolation, ansonsten gibt der Wert die Dauer der Intervalle in Sekunden an, zu denen ein interpolierter Stromverbrauch berechnet wird.
+
 Manuelles Überschreiben des Zählerstands
 ========================================
 

--- a/doc/source/locale/de/LC_MESSAGES/documentation/software_setup.po
+++ b/doc/source/locale/de/LC_MESSAGES/documentation/software_setup.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ESPHome Ferraris Meter \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-16 19:56+0100\n"
+"POT-Creation-Date: 2026-03-24 19:28+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Jens-Uwe Rossbach <devel@jrossbach.de>\n"
 "Language: de\n"
@@ -94,12 +94,12 @@ msgid ""
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:29
-#: ../../source/documentation/software_setup.rst:147
-#: ../../source/documentation/software_setup.rst:164
-#: ../../source/documentation/software_setup.rst:189
-#: ../../source/documentation/software_setup.rst:222
-#: ../../source/documentation/software_setup.rst:263
-#: ../../source/documentation/software_setup.rst:289
+#: ../../source/documentation/software_setup.rst:152
+#: ../../source/documentation/software_setup.rst:169
+#: ../../source/documentation/software_setup.rst:194
+#: ../../source/documentation/software_setup.rst:227
+#: ../../source/documentation/software_setup.rst:268
+#: ../../source/documentation/software_setup.rst:294
 msgid "Beispiel"
 msgstr ""
 
@@ -118,48 +118,48 @@ msgid "Die folgenden allgemeinen Einstellungen können konfiguriert werden:"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:47
-#: ../../source/documentation/software_setup.rst:78
-#: ../../source/documentation/software_setup.rst:94
-#: ../../source/documentation/software_setup.rst:129
+#: ../../source/documentation/software_setup.rst:83
+#: ../../source/documentation/software_setup.rst:99
+#: ../../source/documentation/software_setup.rst:134
 msgid "Option"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:48
-#: ../../source/documentation/software_setup.rst:79
-#: ../../source/documentation/software_setup.rst:95
-#: ../../source/documentation/software_setup.rst:129
-#: ../../source/documentation/software_setup.rst:210
-#: ../../source/documentation/software_setup.rst:244
-#: ../../source/documentation/software_setup.rst:320
-#: ../../source/documentation/software_setup.rst:353
-#: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:84
+#: ../../source/documentation/software_setup.rst:100
+#: ../../source/documentation/software_setup.rst:134
+#: ../../source/documentation/software_setup.rst:215
+#: ../../source/documentation/software_setup.rst:249
+#: ../../source/documentation/software_setup.rst:325
+#: ../../source/documentation/software_setup.rst:358
+#: ../../source/documentation/software_setup.rst:387
 msgid "Typ"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:49
-#: ../../source/documentation/software_setup.rst:80
-#: ../../source/documentation/software_setup.rst:96
-#: ../../source/documentation/software_setup.rst:129
+#: ../../source/documentation/software_setup.rst:85
+#: ../../source/documentation/software_setup.rst:101
+#: ../../source/documentation/software_setup.rst:134
 msgid "Benötigt"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:50
-#: ../../source/documentation/software_setup.rst:81
-#: ../../source/documentation/software_setup.rst:97
-#: ../../source/documentation/software_setup.rst:129
-#: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:86
+#: ../../source/documentation/software_setup.rst:102
+#: ../../source/documentation/software_setup.rst:134
+#: ../../source/documentation/software_setup.rst:387
 msgid "Standard"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:51
-#: ../../source/documentation/software_setup.rst:82
-#: ../../source/documentation/software_setup.rst:98
-#: ../../source/documentation/software_setup.rst:129
-#: ../../source/documentation/software_setup.rst:210
-#: ../../source/documentation/software_setup.rst:245
-#: ../../source/documentation/software_setup.rst:320
-#: ../../source/documentation/software_setup.rst:353
-#: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:87
+#: ../../source/documentation/software_setup.rst:103
+#: ../../source/documentation/software_setup.rst:134
+#: ../../source/documentation/software_setup.rst:215
+#: ../../source/documentation/software_setup.rst:250
+#: ../../source/documentation/software_setup.rst:325
+#: ../../source/documentation/software_setup.rst:358
+#: ../../source/documentation/software_setup.rst:387
 msgid "Beschreibung"
 msgstr ""
 
@@ -168,8 +168,8 @@ msgid "``id``"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:53
-#: ../../source/documentation/software_setup.rst:68
-#: ../../source/documentation/software_setup.rst:100
+#: ../../source/documentation/software_setup.rst:73
+#: ../../source/documentation/software_setup.rst:105
 msgid "`ID <https://www.esphome.io/guides/configuration-types#config-id>`_"
 msgstr ""
 
@@ -178,10 +178,10 @@ msgid "nein [#fn1]_"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:55
-#: ../../source/documentation/software_setup.rst:70
-#: ../../source/documentation/software_setup.rst:86
-#: ../../source/documentation/software_setup.rst:102
-#: ../../source/documentation/software_setup.rst:122
+#: ../../source/documentation/software_setup.rst:75
+#: ../../source/documentation/software_setup.rst:91
+#: ../../source/documentation/software_setup.rst:107
+#: ../../source/documentation/software_setup.rst:127
 msgid "\\-"
 msgstr ""
 
@@ -194,22 +194,24 @@ msgid "``rotations_per_kwh``"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:58
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:133
+#: ../../source/documentation/software_setup.rst:63
 #: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:141
 msgid "Zahl"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:59
 #: ../../source/documentation/software_setup.rst:64
 #: ../../source/documentation/software_setup.rst:69
-#: ../../source/documentation/software_setup.rst:106
+#: ../../source/documentation/software_setup.rst:74
 #: ../../source/documentation/software_setup.rst:111
 #: ../../source/documentation/software_setup.rst:116
 #: ../../source/documentation/software_setup.rst:121
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:133
+#: ../../source/documentation/software_setup.rst:126
 #: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:141
 msgid "nein"
 msgstr ""
 
@@ -224,132 +226,147 @@ msgid ""
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:62
-msgid "``debounce_threshold``"
-msgstr ""
-
-#: ../../source/documentation/software_setup.rst:63
-msgid ""
-"Zahl |nbsp| / |nbsp| `ID <https://www.esphome.io/guides/configuration-"
-"types#config-id>`_ |nbsp| [#fn3]_"
+msgid "``interpolation_interval``"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:65
-msgid "400"
+msgid "10"
 msgstr ""
 
 #: ../../source/documentation/software_setup.rst:66
+msgid ""
+"Dauer des Interpolationsintervalls in Sekunden, ``0``, um die "
+"Interpolation auszuschalten; siehe Abschnitt :ref:`Interpolation bei "
+"fallenden Stromverbräuchen <power-interpolation>` für Details"
+msgstr ""
+
+#: ../../source/documentation/software_setup.rst:67
+msgid "``debounce_threshold``"
+msgstr ""
+
+#: ../../source/documentation/software_setup.rst:68
+msgid ""
+"Zahl |nbsp| / |nbsp| `ID <https://www.esphome.io/guides/configuration-"
+"types#config-id>`_ |nbsp| [#fn2]_"
+msgstr ""
+
+#: ../../source/documentation/software_setup.rst:70
+msgid "400"
+msgstr ""
+
+#: ../../source/documentation/software_setup.rst:71
 msgid ""
 "Minimale Zeit in Millisekunden zwischen fallender und darauffolgender "
 "steigender Flanke, damit die Umdrehung berücksichtigt wird; siehe "
 "Abschnitt :ref:`Entprellungsschwellwert <debounce-threshold>` für Details"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:67
+#: ../../source/documentation/software_setup.rst:72
 msgid "``energy_start_value``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:71
+#: ../../source/documentation/software_setup.rst:76
 msgid ""
 "`Zahlen-Komponente <https://www.esphome.io/components/number>`_, deren "
 "Wert beim Booten als Startwert für den Verbrauchszähler verwendet wird"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:73
+#: ../../source/documentation/software_setup.rst:78
 msgid ""
 "Die folgenden Einstellungen sind nur relevant, wenn der digitale Ausgang "
 "des Infrarotsensors verwendet wird:"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:83
+#: ../../source/documentation/software_setup.rst:88
 msgid "``digital_input``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:84
+#: ../../source/documentation/software_setup.rst:89
 msgid "`Pin <https://www.esphome.io/guides/configuration-types#pin>`_"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:85
-#: ../../source/documentation/software_setup.rst:101
-msgid "ja [#fn2]_"
+#: ../../source/documentation/software_setup.rst:90
+#: ../../source/documentation/software_setup.rst:106
+msgid "ja [#fn3]_"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:87
+#: ../../source/documentation/software_setup.rst:92
 msgid "GPIO-Pin, mit dem der digitale Ausgang des TCRT5000-Moduls verbunden ist"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:89
+#: ../../source/documentation/software_setup.rst:94
 msgid ""
 "Die folgenden Einstellungen sind nur relevant, wenn der analoge Ausgang "
 "des Infrarotsensors verwendet wird:"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:99
+#: ../../source/documentation/software_setup.rst:104
 msgid "``analog_input``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:103
+#: ../../source/documentation/software_setup.rst:108
 msgid ""
 "`ADC-Sensor <https://www.esphome.io/components/sensor/adc.html>`_, der "
 "den mit dem analogen Ausgang des TCRT5000-Moduls verbundenen Pin ausliest"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:104
+#: ../../source/documentation/software_setup.rst:109
 msgid "``analog_threshold``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:105
 #: ../../source/documentation/software_setup.rst:110
 #: ../../source/documentation/software_setup.rst:115
+#: ../../source/documentation/software_setup.rst:120
 msgid ""
 "Zahl |nbsp| / |nbsp| `ID <https://www.esphome.io/guides/configuration-"
 "types#config-id>`_"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:107
+#: ../../source/documentation/software_setup.rst:112
 msgid "50.0"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:108
+#: ../../source/documentation/software_setup.rst:113
 msgid ""
 "Schwellwert für die Erkennung einer Umdrehung über den analogen Eingang, "
 "siehe Abschnitt :ref:`Kalibrierung des analogen Ausgangssignals <analog-"
 "calibration>` für Details"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:109
+#: ../../source/documentation/software_setup.rst:114
 msgid "``off_tolerance``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:112
 #: ../../source/documentation/software_setup.rst:117
+#: ../../source/documentation/software_setup.rst:122
 msgid "0.0"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:113
+#: ../../source/documentation/software_setup.rst:118
 msgid ""
 "Negativer Versatz zum analogen Schwellwert für die fallende Flanke, siehe"
 " Abschnitt :ref:`Hysterese-Kennlinie <hysteresis-curve>` für Details"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:114
+#: ../../source/documentation/software_setup.rst:119
 msgid "``on_tolerance``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:118
+#: ../../source/documentation/software_setup.rst:123
 msgid ""
 "Positiver Versatz zum analogen Schwellwert für die steigende Flanke, "
 "siehe Abschnitt :ref:`Hysterese-Kennlinie <hysteresis-curve>` für Details"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:119
+#: ../../source/documentation/software_setup.rst:124
 msgid "``calibrate_on_boot``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:120
+#: ../../source/documentation/software_setup.rst:125
 msgid "Objekt"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:123
+#: ../../source/documentation/software_setup.rst:128
 msgid ""
 "Wenn vorhanden, wird die automatische Kalibrierung des analogen "
 "Ausgangssignals vom Infrarotsensor nach dem Aufstarten ausgeführt, siehe "
@@ -357,76 +374,69 @@ msgid ""
 "calibration>` für Details"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:126
+#: ../../source/documentation/software_setup.rst:131
 msgid ""
 "Die folgenden Einstellungen können für das Objekt ``calibrate_on_boot`` "
 "konfiguriert werden:"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:389
 msgid "``num_captured_values``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:389
 msgid "6000"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:389
 msgid "Anzahl der zu erfassenden analogen Werte pro Kalibrierungsdurchlauf"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:133
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:391
 msgid "``min_level_distance``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:133
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:391
 msgid "6.0"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:133
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:391
 msgid ""
 "Mindestdifferenz zwischen niedrigstem und höchstem Analogwert, damit die "
 "Kalibrierung als erfolgreich angesehen und der analoge Schwellwert "
 "gesetzt wird"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:136
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:141
+#: ../../source/documentation/software_setup.rst:393
 msgid "``max_iterations``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:136
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:141
+#: ../../source/documentation/software_setup.rst:393
 msgid "3"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:136
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:141
+#: ../../source/documentation/software_setup.rst:393
 msgid ""
 "Maximale Anzahl fehlgeschlagener Kalibrierungsdurchläufe, bevor "
 "aufgegeben wird"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:140
+#: ../../source/documentation/software_setup.rst:145
 msgid ""
 "Bestimmte :ref:`Anwendungsfälle <usage-examples>` benötigen das "
 "Konfigurationselement ``id``."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:142
-msgid ""
-"Nur eines der beiden Konfigurationselemente - ``digital_input`` oder "
-"``analog_input`` - wird benötigt, je nach :ref:`Hardware-Aufbauvariante "
-"<hardware-setup>`."
-msgstr ""
-
-#: ../../source/documentation/software_setup.rst:144
+#: ../../source/documentation/software_setup.rst:147
 msgid ""
 "Die Konfigurationselemente ``analog_threshold``\\ , ``off_tolerance``\\ ,"
 " ``on_tolerance`` und ``debounce_threshold`` erwarten entweder eine feste"
@@ -437,11 +447,18 @@ msgid ""
 "<https://www.esphome.io/components/number/template.html>`_\\ )."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:159
+#: ../../source/documentation/software_setup.rst:149
+msgid ""
+"Nur eines der beiden Konfigurationselemente - ``digital_input`` oder "
+"``analog_input`` - wird benötigt, je nach :ref:`Hardware-Aufbauvariante "
+"<hardware-setup>`."
+msgstr ""
+
+#: ../../source/documentation/software_setup.rst:164
 msgid "API/MQTT-Komponente"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:161
+#: ../../source/documentation/software_setup.rst:166
 msgid ""
 "Eine `API-Komponente <https://www.esphome.io/components/api.html>`_ ist "
 "erforderlich, wenn der ESP in Home Assistant integriert werden soll. Für "
@@ -453,34 +470,34 @@ msgid ""
 " einem Neustart (siehe weiter unten für Details) u.U. nicht mehr."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:166
+#: ../../source/documentation/software_setup.rst:171
 msgid ""
 "Nachfolgend ein Beispiel für die Integration mit Home Assistant (und "
 "verschlüsselter API):"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:174
+#: ../../source/documentation/software_setup.rst:179
 msgid ""
 "Und hier ein Beispiel für die Verwendung mit einer alternativen "
 "Hausautomatisierungs-Software mittels MQTT:"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:184
+#: ../../source/documentation/software_setup.rst:189
 msgid "WiFi-Komponente"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:186
+#: ../../source/documentation/software_setup.rst:191
 msgid ""
 "Eine `WiFi-Komponente <https://www.esphome.io/components/wifi.html>`_ "
 "sollte vorhanden sein, da die Sensor-Werte ansonsten nicht ohne weiteres "
 "an ein anderes Gerät übertragen werden können."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:198
+#: ../../source/documentation/software_setup.rst:203
 msgid "Sensoren"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:200
+#: ../../source/documentation/software_setup.rst:205
 msgid ""
 "Die Ferraris-Plattform verfügt über primäre Sensoren, um die berechneten "
 "Verbrauchswerte auszugeben sowie über diagnostische Sensoren für den "
@@ -488,137 +505,137 @@ msgid ""
 "werden, wenn sie nicht benötigt werden."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:205
+#: ../../source/documentation/software_setup.rst:210
 msgid "Primäre Sensoren"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:207
+#: ../../source/documentation/software_setup.rst:212
 msgid "Die folgenden primären Sensoren können konfiguriert werden:"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:210
-#: ../../source/documentation/software_setup.rst:243
+#: ../../source/documentation/software_setup.rst:215
+#: ../../source/documentation/software_setup.rst:248
 msgid "Sensor"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:210
+#: ../../source/documentation/software_setup.rst:215
 msgid "Geräteklasse"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:210
+#: ../../source/documentation/software_setup.rst:215
 msgid "Zustandsklasse"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:210
+#: ../../source/documentation/software_setup.rst:215
 msgid "Einheit"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "``power_consumption``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:212
-#: ../../source/documentation/software_setup.rst:214
-#: ../../source/documentation/software_setup.rst:256
+#: ../../source/documentation/software_setup.rst:217
+#: ../../source/documentation/software_setup.rst:219
+#: ../../source/documentation/software_setup.rst:261
 msgid "numerisch"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "``power``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "``measurement``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "W"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "Aktueller Stromverbrauch"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "``energy_meter``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "``energy``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "``total_increasing``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "Wh"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "Gesamtstromverbrauch (Stromzähler/Zählerstand)"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:219
+#: ../../source/documentation/software_setup.rst:224
 msgid ""
 "Detaillierte Informationen zu den Konfigurationsmöglichkeiten der "
 "einzelnen Elemente findest du in der Dokumentation der `ESPHome "
 "Sensorkomponenten <https://www.esphome.io/components/sensor>`_."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:236
+#: ../../source/documentation/software_setup.rst:241
 msgid "Diagnostische Sensoren"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:238
+#: ../../source/documentation/software_setup.rst:243
 msgid "Die folgenden diagnostischen Sensoren können konfiguriert werden:"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:246
+#: ../../source/documentation/software_setup.rst:251
 msgid "``rotation_indicator``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:247
-#: ../../source/documentation/software_setup.rst:250
-#: ../../source/documentation/software_setup.rst:253
+#: ../../source/documentation/software_setup.rst:252
+#: ../../source/documentation/software_setup.rst:255
+#: ../../source/documentation/software_setup.rst:258
 msgid "binär"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:248
+#: ../../source/documentation/software_setup.rst:253
 msgid ""
 "Zeigt an, ob die Markierung auf der Drehscheibe gerade vor dem "
 "Infrarotsensor ist (funktioniert nur im Kalibrierungsmodus)"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:249
+#: ../../source/documentation/software_setup.rst:254
 msgid "``analog_calibration_state``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:251
+#: ../../source/documentation/software_setup.rst:256
 msgid "Status der automatischen analogen Kalibrierung (ob aktiv oder nicht)"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:252
+#: ../../source/documentation/software_setup.rst:257
 msgid "``analog_calibration_result``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:254
+#: ../../source/documentation/software_setup.rst:259
 msgid ""
 "Ergebnis der letzten automatischen analogen Kalibrierung (ob erfolgreich "
 "oder nicht)"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:255
+#: ../../source/documentation/software_setup.rst:260
 msgid "``analog_value_spectrum``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:257
+#: ../../source/documentation/software_setup.rst:262
 msgid ""
 "Bandbreite der analogen Werte (Differenz zwischen kleinstem und größtem "
 "analogen Wert)"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:260
+#: ../../source/documentation/software_setup.rst:265
 msgid ""
 "Detaillierte Informationen zu den Konfigurationsmöglichkeiten der "
 "einzelnen Elemente findest du in der Dokumentation der `ESPHome "
@@ -627,11 +644,11 @@ msgid ""
 "Sensorkomponenten <https://www.esphome.io/components/sensor>`_."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:284
+#: ../../source/documentation/software_setup.rst:289
 msgid "Aktoren"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:286
+#: ../../source/documentation/software_setup.rst:291
 msgid ""
 "Zu diagnostischen Zwecken verfügt die Ferraris-Plattform über einen "
 "`Schalter <https://www.esphome.io/components/switch>`_. Dieser hat den "
@@ -640,66 +657,66 @@ msgid ""
 ":ref:`Kalibrierung <calibration>` für weitere Informationen)."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:301
+#: ../../source/documentation/software_setup.rst:306
 msgid "Aktionen"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:303
+#: ../../source/documentation/software_setup.rst:308
 msgid ""
 "Die Ferraris-Plattform stellt verschiedene Aktionen zur Verfügung, um "
 "Werte zu setzen oder das Verhalten zu steuern."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:306
+#: ../../source/documentation/software_setup.rst:311
 msgid "Zählerstand setzen"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:314
+#: ../../source/documentation/software_setup.rst:319
 msgid "Setzt den Zählerstand auf den angegeben Wert."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:317
-#: ../../source/documentation/software_setup.rst:320
-#: ../../source/documentation/software_setup.rst:350
-#: ../../source/documentation/software_setup.rst:353
-#: ../../source/documentation/software_setup.rst:377
+#: ../../source/documentation/software_setup.rst:322
+#: ../../source/documentation/software_setup.rst:325
+#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:358
 #: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:387
 msgid "Parameter"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:320
-#: ../../source/documentation/software_setup.rst:353
-#: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:325
+#: ../../source/documentation/software_setup.rst:358
+#: ../../source/documentation/software_setup.rst:387
 msgid "Bereich"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:322
-#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:327
+#: ../../source/documentation/software_setup.rst:360
 msgid "``value``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:322
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:327
+#: ../../source/documentation/software_setup.rst:391
 msgid "``float``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:322
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:327
+#: ../../source/documentation/software_setup.rst:391
 msgid ">= 0"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:322
+#: ../../source/documentation/software_setup.rst:327
 msgid "Zielwert für den Zählerstand in Kilowattstunden (kWh)"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:326
-#: ../../source/documentation/software_setup.rst:359
+#: ../../source/documentation/software_setup.rst:331
+#: ../../source/documentation/software_setup.rst:364
 msgid ""
 "Anstelle eines festen Zahlenwerts kann auch ein Lambda-Ausdruck verwendet"
 " werden, der den zu übergebenden Wert zurückgibt."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:330
+#: ../../source/documentation/software_setup.rst:335
 msgid ""
 "Obwohl der Sensor für den aktuellen Zählerstand die Einheit **Wh "
 "(Wattstunden)** hat, verwendet die Aktion zum Überschreiben des "
@@ -708,44 +725,44 @@ msgid ""
 " anzeigen."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:334
+#: ../../source/documentation/software_setup.rst:339
 msgid "Umdrehungszähler setzen"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:342
+#: ../../source/documentation/software_setup.rst:347
 msgid "Setzt den Umdrehungszähler auf den angegeben Wert."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:346
+#: ../../source/documentation/software_setup.rst:351
 msgid ""
 "Die Aktion zum Setzen des Zählerstands setzt indirekt auch den "
 "Umdrehungszähler, da die Ferraris-Komponente intern mit Umdrehungen und "
 "nicht mit Wattstunden oder Kilowattstunden arbeitet."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:360
 msgid "``uint64``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:360
 msgid "\\>= 0"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:360
 msgid "Zielwert für den Umdrehungszähler in Anzahl Umdrehungen"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:362
+#: ../../source/documentation/software_setup.rst:367
 msgid "Automatische analoge Kalibrierung"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:372
+#: ../../source/documentation/software_setup.rst:377
 msgid ""
 "Startet die automatische Kalibrierung des analogen Ausgangssignals vom "
 "Infrarotsensor."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:374
+#: ../../source/documentation/software_setup.rst:379
 msgid ""
 "Wird die Mindestdifferenz zwischen niedrigstem und höchstem Analogwert "
 "nach Erfassen aller Werte nicht erreicht, gilt die Kalibrierung als "
@@ -753,23 +770,23 @@ msgid ""
 "Anzahl Durchläufe erreicht wurde)."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:379
+#: ../../source/documentation/software_setup.rst:384
 msgid "Alle Parameter sind optional und können weggelassen werden."
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:389
 msgid "``uint32``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:389
 msgid "100 |nbsp| ... |nbsp| 100000"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:393
 msgid "``uint16``"
 msgstr ""
 
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:393
 msgid "1 |nbsp| ... |nbsp| 10000"
 msgstr ""
 
@@ -794,5 +811,20 @@ msgstr ""
 #~ msgid ""
 #~ "Startet die automatische Kalibrierung des "
 #~ "analogen Ausgangssignals vom Infrarotsensor"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Zahl |nbsp| / |nbsp| `ID "
+#~ "<https://www.esphome.io/guides/configuration-types#config-"
+#~ "id>`_ |nbsp| [#fn3]_"
+#~ msgstr ""
+
+#~ msgid "ja [#fn2]_"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Dauer des Interpolationsintervalls in "
+#~ "Sekunden, ``0``, um die Interpolation "
+#~ "auszuschalten"
 #~ msgstr ""
 

--- a/doc/source/locale/de/LC_MESSAGES/documentation/usage_examples.po
+++ b/doc/source/locale/de/LC_MESSAGES/documentation/usage_examples.po
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ESPHome Ferraris Meter \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-16 19:56+0100\n"
+"POT-Creation-Date: 2026-03-25 19:27+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Jens-Uwe Rossbach <devel@jrossbach.de>\n"
 "Language: de\n"
@@ -490,11 +490,47 @@ msgid ""
 "Eingangssignals des Infrarotsensors."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:445
+#: ../../source/documentation/usage_examples.rst:447
+msgid "Interpolation bei fallenden Stromverbräuchen"
+msgstr ""
+
+#: ../../source/documentation/usage_examples.rst:449
+msgid ""
+"Niedrige Stromverbräuche äußern sich in einer langsamen Geschwindigkeit "
+"der Drehscheibe. Dies führt dazu, dass die Markierung auf der Drehscheibe"
+" nur selten am Sensor vorbei fährt und dadurch aktualisiert sich der "
+"Stromverbrauch ebensfalls nur in großen Zeitabständen. Besonders störend "
+"ist dies, wenn ein hoher Stromverbrauch vorliegt und dieser sich dann "
+"rasch absenkt. In diesem Fall dauert es sehr lang, bis der neue niedrige "
+"Stromverbrauch gemeldet wird, da es lange dauert, bis die Markierung "
+"wieder den Sensor passiert. In dieser Zeit wird dann weiterhin ein hoher "
+"Stromverbrauch angezeigt, obwohl der tatsächliche Stromverbrauch viel "
+"niedriger ist."
+msgstr ""
+
+#: ../../source/documentation/usage_examples.rst:451
+msgid ""
+"Um diesem Effekt entgegenzuwirken, kann die Ferraris-Komponente bei "
+"Übergängen von hohen zu niedrigen Stromverbräuchen den tatsächlichen "
+"Verbrauchsverlauf interpolieren und sich somit dem tatsächlichen "
+"Stromverbrauch immer weiter annähern, bis der tatsächliche Stromverbrauch"
+" nach Detektierung der Markierung berechnet und gemeldet wird."
+msgstr ""
+
+#: ../../source/documentation/usage_examples.rst:453
+msgid ""
+"Die Interpolation kann über das Interpolationsintervall "
+"``interpolation_interval`` gesteuert werden. Ein Wert von ``0`` "
+"deaktiviert die Interpolation, ansonsten gibt der Wert die Dauer der "
+"Intervalle in Sekunden an, zu denen ein interpolierter Stromverbrauch "
+"berechnet wird."
+msgstr ""
+
+#: ../../source/documentation/usage_examples.rst:456
 msgid "Manuelles Überschreiben des Zählerstands"
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:447
+#: ../../source/documentation/usage_examples.rst:458
 msgid ""
 "Um den Zählerstand in der Ferraris-Komponente mit dem tatsächlichen "
 "Zählerstand des Ferraris-Stromzählers abzugleichen, kann der Wert des "
@@ -504,14 +540,14 @@ msgid ""
 "Verfügung gestellt."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:451
+#: ../../source/documentation/usage_examples.rst:462
 msgid ""
 "Normalerweise ist nur eine der beiden Aktionen nötig, je nachdem, ob man "
 "den Zählerstand in Kilowattstunden oder lieber in Anzahl Umdrehungen "
 "setzen möchte."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:454
+#: ../../source/documentation/usage_examples.rst:465
 msgid ""
 "Abhängig davon, ob das Setzen des Zählerstands händisch über das User-"
 "Interface oder automatisiert über Automationen und Skripte erfolgen soll,"
@@ -520,24 +556,24 @@ msgid ""
 "aber noch weitere, hier nicht beschriebene Möglichkeiten."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:457
+#: ../../source/documentation/usage_examples.rst:468
 msgid "Händisches Setzen des Zählerstands über das User-Interface"
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:459
+#: ../../source/documentation/usage_examples.rst:470
 msgid ""
 "Dafür führt man beispielsweise folgende Konfigurations-Schritte durch (in"
 " diesem Beispiel zum Setzen des Zählerstands als Kilowattstunden-Wert):"
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:461
+#: ../../source/documentation/usage_examples.rst:472
 msgid ""
 "In der YAML-Konfigurationsdatei wird eine `Template-Zahlen-Komponente "
 "<https://www.esphome.io/components/number/template.html>`_ angelegt und "
 "für einen Zählerstand in der Einheit Kilowattstunden konfiguriert."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:479
+#: ../../source/documentation/usage_examples.rst:490
 msgid ""
 "In der YAML-Konfigurationsdatei wird ein `Template-Button "
 "<https://www.esphome.io/components/button/template.html>`_ angelegt und "
@@ -546,15 +582,15 @@ msgid ""
 "angelegten Zahlen-Komponente gelesen."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:496
+#: ../../source/documentation/usage_examples.rst:507
 msgid "Automatisiertes Setzen des Zählerstands"
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:498
+#: ../../source/documentation/usage_examples.rst:509
 msgid "Dafür führt man beispielsweise folgende Konfigurations-Schritte durch:"
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:500
+#: ../../source/documentation/usage_examples.rst:511
 msgid ""
 "In der YAML-Konfigurationsdatei wird eine `benutzerdefinierte Aktion "
 "<https://www.esphome.io/components/api.html#api-device-actions>`_ "
@@ -562,7 +598,7 @@ msgid ""
 "Aktion ``ferraris.set_energy_meter``) aufruft."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:518
+#: ../../source/documentation/usage_examples.rst:529
 msgid ""
 "In Home Assistant wird eine `Automation <https://www.home-"
 "assistant.io/docs/automation>`_ erstellt, die die benutzerdefinierte "
@@ -570,11 +606,11 @@ msgid ""
 "Anfang eines jeden Monats zurückgesetzt)."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:537
+#: ../../source/documentation/usage_examples.rst:548
 msgid "Wiederherstellung des Zählerstands nach einem Neustart"
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:539
+#: ../../source/documentation/usage_examples.rst:550
 msgid ""
 "Um die Lebensdauer des Flash-Speichers auf dem ESP-Mikrocontroller nicht "
 "zu verringern, speichert die Ferraris-Komponente keine Daten persistent "
@@ -588,13 +624,13 @@ msgid ""
 " diesen zu übertragen."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:541
+#: ../../source/documentation/usage_examples.rst:552
 msgid ""
 "Damit dies funktioniert, müssen beispielsweise folgende Konfigurations-"
 "Schritte durchgeführt werden:"
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:544
+#: ../../source/documentation/usage_examples.rst:555
 msgid ""
 "In Home Assistant wird ein `Zahlenwert-Eingabehelfer <https://www.home-"
 "assistant.io/integrations/input_number>`_ angelegt (in diesem Beispiel "
@@ -605,13 +641,13 @@ msgid ""
 " die den angelegten Zahlenwert-Eingabehelfer importiert."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:553
+#: ../../source/documentation/usage_examples.rst:564
 msgid ""
 "Unter der Konfiguration der Ferraris-Komponente verweist der Eintrag "
 "``energy_start_value`` auf die angelegte Zahlen-Komponente."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:561
+#: ../../source/documentation/usage_examples.rst:572
 msgid ""
 "In Home Assistant wird eine `Automation <https://www.home-"
 "assistant.io/docs/automation/basics>`_ erstellt, die bei Änderung des "
@@ -619,7 +655,7 @@ msgid ""
 "Zahlenwert-Eingabehelfer kopiert."
 msgstr ""
 
-#: ../../source/documentation/usage_examples.rst:580
+#: ../../source/documentation/usage_examples.rst:591
 msgid ""
 "Alternativ kann auch eine `Sensor-Automation "
 "<https://www.esphome.io/components/sensor/#sensor-automation>`_ für den "
@@ -770,5 +806,38 @@ msgstr ""
 #~ "<https://www.esphome.io/components/number/homeassistant.html>`_ "
 #~ "angelegt, die den angelegten Zahlenwert-"
 #~ "Eingabehelfer importiert."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Niedrige Stromverbräuche äußern sich in "
+#~ "einer langsamen Geschwindigkeit der "
+#~ "Drehscheibe. Dies führt dazu, dass die"
+#~ " Markierung auf der Drehscheibe nur "
+#~ "selten am Sensor vorbei fährt und "
+#~ "dadurch aktualisiert sich der Stromverbrauch"
+#~ " ebensfalls nur in großen Zeitabständen."
+#~ " Besonders störend ist dies, wenn ein"
+#~ " hoher Stromverbrauch vorliegt und dieser"
+#~ " sich dann rasch absenkt. In diesem"
+#~ " Fall dauert es sehr lang, bis "
+#~ "der neue niedrige Stromverbrauch gemeldet "
+#~ "wird, da es lange dauert, bis die"
+#~ " Markierung wieder den Sensor passiert. "
+#~ "In dieser Zeit wird dann weiterhin "
+#~ "ein hoher Stromverbrauch angezeigt, obwohl "
+#~ "der tatsächliche Stromverbrauch viel nidriger"
+#~ " ist."
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Um diesem Effekt entgegenzuwirken, kann "
+#~ "die Ferraris Meter Komponente bei "
+#~ "Übergängen von hohen zu niedrigen "
+#~ "Stromverbräuchen den tatsächlichen Verbrauchsverlauf"
+#~ " interpolieren und sich somit dem "
+#~ "tatsächlichen Stromverbrauch immer weiter "
+#~ "annähern, bis der tatsächliche Stromverbrauch"
+#~ " nach Detektierung der Markierung berechnet"
+#~ " und gemeldet wird."
 #~ msgstr ""
 

--- a/doc/source/locale/en/LC_MESSAGES/documentation/software_setup.po
+++ b/doc/source/locale/en/LC_MESSAGES/documentation/software_setup.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ESPHome Ferraris Meter \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-16 19:56+0100\n"
+"POT-Creation-Date: 2026-03-24 19:28+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Jens-Uwe Rossbach <devel@jrossbach.de>\n"
 "Language: en\n"
@@ -104,7 +104,7 @@ msgid ""
 "Plattform und muss hinzugefügt werden, um deren Sensoren, -Aktoren und "
 "-Aktionen zu verwenden."
 msgstr ""
-"The Ferraris component (\\ ``ferraris``\\ ) is the base of the Ferraris "
+"The Ferraris component (``ferraris``) is the base of the Ferraris "
 "platform and must be added in order to use its sensors, actors and "
 "actions."
 
@@ -119,12 +119,12 @@ msgstr ""
 "from this repository."
 
 #: ../../source/documentation/software_setup.rst:29
-#: ../../source/documentation/software_setup.rst:147
-#: ../../source/documentation/software_setup.rst:164
-#: ../../source/documentation/software_setup.rst:189
-#: ../../source/documentation/software_setup.rst:222
-#: ../../source/documentation/software_setup.rst:263
-#: ../../source/documentation/software_setup.rst:289
+#: ../../source/documentation/software_setup.rst:152
+#: ../../source/documentation/software_setup.rst:169
+#: ../../source/documentation/software_setup.rst:194
+#: ../../source/documentation/software_setup.rst:227
+#: ../../source/documentation/software_setup.rst:268
+#: ../../source/documentation/software_setup.rst:294
 msgid "Beispiel"
 msgstr "Example"
 
@@ -149,48 +149,48 @@ msgid "Die folgenden allgemeinen Einstellungen können konfiguriert werden:"
 msgstr "The following common configuration items can be configured:"
 
 #: ../../source/documentation/software_setup.rst:47
-#: ../../source/documentation/software_setup.rst:78
-#: ../../source/documentation/software_setup.rst:94
-#: ../../source/documentation/software_setup.rst:129
+#: ../../source/documentation/software_setup.rst:83
+#: ../../source/documentation/software_setup.rst:99
+#: ../../source/documentation/software_setup.rst:134
 msgid "Option"
 msgstr "Option"
 
 #: ../../source/documentation/software_setup.rst:48
-#: ../../source/documentation/software_setup.rst:79
-#: ../../source/documentation/software_setup.rst:95
-#: ../../source/documentation/software_setup.rst:129
-#: ../../source/documentation/software_setup.rst:210
-#: ../../source/documentation/software_setup.rst:244
-#: ../../source/documentation/software_setup.rst:320
-#: ../../source/documentation/software_setup.rst:353
-#: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:84
+#: ../../source/documentation/software_setup.rst:100
+#: ../../source/documentation/software_setup.rst:134
+#: ../../source/documentation/software_setup.rst:215
+#: ../../source/documentation/software_setup.rst:249
+#: ../../source/documentation/software_setup.rst:325
+#: ../../source/documentation/software_setup.rst:358
+#: ../../source/documentation/software_setup.rst:387
 msgid "Typ"
 msgstr "Type"
 
 #: ../../source/documentation/software_setup.rst:49
-#: ../../source/documentation/software_setup.rst:80
-#: ../../source/documentation/software_setup.rst:96
-#: ../../source/documentation/software_setup.rst:129
+#: ../../source/documentation/software_setup.rst:85
+#: ../../source/documentation/software_setup.rst:101
+#: ../../source/documentation/software_setup.rst:134
 msgid "Benötigt"
 msgstr "Required"
 
 #: ../../source/documentation/software_setup.rst:50
-#: ../../source/documentation/software_setup.rst:81
-#: ../../source/documentation/software_setup.rst:97
-#: ../../source/documentation/software_setup.rst:129
-#: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:86
+#: ../../source/documentation/software_setup.rst:102
+#: ../../source/documentation/software_setup.rst:134
+#: ../../source/documentation/software_setup.rst:387
 msgid "Standard"
 msgstr "Default"
 
 #: ../../source/documentation/software_setup.rst:51
-#: ../../source/documentation/software_setup.rst:82
-#: ../../source/documentation/software_setup.rst:98
-#: ../../source/documentation/software_setup.rst:129
-#: ../../source/documentation/software_setup.rst:210
-#: ../../source/documentation/software_setup.rst:245
-#: ../../source/documentation/software_setup.rst:320
-#: ../../source/documentation/software_setup.rst:353
-#: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:87
+#: ../../source/documentation/software_setup.rst:103
+#: ../../source/documentation/software_setup.rst:134
+#: ../../source/documentation/software_setup.rst:215
+#: ../../source/documentation/software_setup.rst:250
+#: ../../source/documentation/software_setup.rst:325
+#: ../../source/documentation/software_setup.rst:358
+#: ../../source/documentation/software_setup.rst:387
 msgid "Beschreibung"
 msgstr "Description"
 
@@ -199,8 +199,8 @@ msgid "``id``"
 msgstr "``id``"
 
 #: ../../source/documentation/software_setup.rst:53
-#: ../../source/documentation/software_setup.rst:68
-#: ../../source/documentation/software_setup.rst:100
+#: ../../source/documentation/software_setup.rst:73
+#: ../../source/documentation/software_setup.rst:105
 msgid "`ID <https://www.esphome.io/guides/configuration-types#config-id>`_"
 msgstr "`ID <https://www.esphome.io/guides/configuration-types#config-id>`_"
 
@@ -209,10 +209,10 @@ msgid "nein [#fn1]_"
 msgstr "no [#fn1]_"
 
 #: ../../source/documentation/software_setup.rst:55
-#: ../../source/documentation/software_setup.rst:70
-#: ../../source/documentation/software_setup.rst:86
-#: ../../source/documentation/software_setup.rst:102
-#: ../../source/documentation/software_setup.rst:122
+#: ../../source/documentation/software_setup.rst:75
+#: ../../source/documentation/software_setup.rst:91
+#: ../../source/documentation/software_setup.rst:107
+#: ../../source/documentation/software_setup.rst:127
 msgid "\\-"
 msgstr "\\-"
 
@@ -225,22 +225,24 @@ msgid "``rotations_per_kwh``"
 msgstr "``rotations_per_kwh``"
 
 #: ../../source/documentation/software_setup.rst:58
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:133
+#: ../../source/documentation/software_setup.rst:63
 #: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:141
 msgid "Zahl"
 msgstr "Number"
 
 #: ../../source/documentation/software_setup.rst:59
 #: ../../source/documentation/software_setup.rst:64
 #: ../../source/documentation/software_setup.rst:69
-#: ../../source/documentation/software_setup.rst:106
+#: ../../source/documentation/software_setup.rst:74
 #: ../../source/documentation/software_setup.rst:111
 #: ../../source/documentation/software_setup.rst:116
 #: ../../source/documentation/software_setup.rst:121
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:133
+#: ../../source/documentation/software_setup.rst:126
 #: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:141
 msgid "nein"
 msgstr "no"
 
@@ -257,22 +259,40 @@ msgstr ""
 " on the Ferraris electricity meter)"
 
 #: ../../source/documentation/software_setup.rst:62
+msgid "``interpolation_interval``"
+msgstr "``interpolation_interval``"
+
+#: ../../source/documentation/software_setup.rst:65
+msgid "10"
+msgstr "10"
+
+#: ../../source/documentation/software_setup.rst:66
+msgid ""
+"Dauer des Interpolationsintervalls in Sekunden, ``0``, um die "
+"Interpolation auszuschalten; siehe Abschnitt :ref:`Interpolation bei "
+"fallenden Stromverbräuchen <power-interpolation>` für Details"
+msgstr ""
+"Duration of the interpolation interval in seconds, ``0`` to "
+"deactivate interpolation; see section :ref:`Interpolation at falling "
+"Power Consumption <power-interpolation>` for details"
+
+#: ../../source/documentation/software_setup.rst:67
 msgid "``debounce_threshold``"
 msgstr "``debounce_threshold``"
 
-#: ../../source/documentation/software_setup.rst:63
+#: ../../source/documentation/software_setup.rst:68
 msgid ""
 "Zahl |nbsp| / |nbsp| `ID <https://www.esphome.io/guides/configuration-"
-"types#config-id>`_ |nbsp| [#fn3]_"
+"types#config-id>`_ |nbsp| [#fn2]_"
 msgstr ""
 "Number |nbsp| / |nbsp| `ID <https://www.esphome.io/guides/configuration-"
-"types#config-id>`_ |nbsp| [#fn3]_"
+"types#config-id>`_ |nbsp| [#fn2]_"
 
-#: ../../source/documentation/software_setup.rst:65
+#: ../../source/documentation/software_setup.rst:70
 msgid "400"
 msgstr "400"
 
-#: ../../source/documentation/software_setup.rst:66
+#: ../../source/documentation/software_setup.rst:71
 msgid ""
 "Minimale Zeit in Millisekunden zwischen fallender und darauffolgender "
 "steigender Flanke, damit die Umdrehung berücksichtigt wird; siehe "
@@ -282,11 +302,11 @@ msgstr ""
 "to take the rotation into account, see section :ref:`Debounce Threshold "
 "<debounce-threshold>` for details"
 
-#: ../../source/documentation/software_setup.rst:67
+#: ../../source/documentation/software_setup.rst:72
 msgid "``energy_start_value``"
 msgstr "``energy_start_value``"
 
-#: ../../source/documentation/software_setup.rst:71
+#: ../../source/documentation/software_setup.rst:76
 msgid ""
 "`Zahlen-Komponente <https://www.esphome.io/components/number>`_, deren "
 "Wert beim Booten als Startwert für den Verbrauchszähler verwendet wird"
@@ -294,7 +314,7 @@ msgstr ""
 "`Number component <https://www.esphome.io/components/number>`_ whose "
 "value will be used as starting value for the energy counter at boot time"
 
-#: ../../source/documentation/software_setup.rst:73
+#: ../../source/documentation/software_setup.rst:78
 msgid ""
 "Die folgenden Einstellungen sind nur relevant, wenn der digitale Ausgang "
 "des Infrarotsensors verwendet wird:"
@@ -302,24 +322,24 @@ msgstr ""
 "The following configuration items are only relevant, if the digital "
 "output of the infrared sensor is used:"
 
-#: ../../source/documentation/software_setup.rst:83
+#: ../../source/documentation/software_setup.rst:88
 msgid "``digital_input``"
 msgstr "``digital_input``"
 
-#: ../../source/documentation/software_setup.rst:84
+#: ../../source/documentation/software_setup.rst:89
 msgid "`Pin <https://www.esphome.io/guides/configuration-types#pin>`_"
 msgstr "`Pin <https://www.esphome.io/guides/configuration-types#pin>`_"
 
-#: ../../source/documentation/software_setup.rst:85
-#: ../../source/documentation/software_setup.rst:101
-msgid "ja [#fn2]_"
-msgstr "yes [#fn2]_"
+#: ../../source/documentation/software_setup.rst:90
+#: ../../source/documentation/software_setup.rst:106
+msgid "ja [#fn3]_"
+msgstr "yes [#fn3]_"
 
-#: ../../source/documentation/software_setup.rst:87
+#: ../../source/documentation/software_setup.rst:92
 msgid "GPIO-Pin, mit dem der digitale Ausgang des TCRT5000-Moduls verbunden ist"
 msgstr "GPIO pin to which the digital output of the TCRT5000 module is connected"
 
-#: ../../source/documentation/software_setup.rst:89
+#: ../../source/documentation/software_setup.rst:94
 msgid ""
 "Die folgenden Einstellungen sind nur relevant, wenn der analoge Ausgang "
 "des Infrarotsensors verwendet wird:"
@@ -327,25 +347,25 @@ msgstr ""
 "The following configuration items are only relevant, if the analog output"
 " of the infrared sensor is used:"
 
-#: ../../source/documentation/software_setup.rst:99
+#: ../../source/documentation/software_setup.rst:104
 msgid "``analog_input``"
 msgstr "``analog_input``"
 
-#: ../../source/documentation/software_setup.rst:103
+#: ../../source/documentation/software_setup.rst:108
 msgid ""
 "`ADC-Sensor <https://www.esphome.io/components/sensor/adc.html>`_, der "
 "den mit dem analogen Ausgang des TCRT5000-Moduls verbundenen Pin ausliest"
 msgstr ""
-"ADC sensor <https://www.esphome.io/components/sensor/adc.html>`_ which "
+"`ADC sensor <https://www.esphome.io/components/sensor/adc.html>`_ which "
 "reads out the pin connected to the analog output of the TCRT5000 module"
 
-#: ../../source/documentation/software_setup.rst:104
+#: ../../source/documentation/software_setup.rst:109
 msgid "``analog_threshold``"
 msgstr "``analog_threshold``"
 
-#: ../../source/documentation/software_setup.rst:105
 #: ../../source/documentation/software_setup.rst:110
 #: ../../source/documentation/software_setup.rst:115
+#: ../../source/documentation/software_setup.rst:120
 msgid ""
 "Zahl |nbsp| / |nbsp| `ID <https://www.esphome.io/guides/configuration-"
 "types#config-id>`_"
@@ -353,11 +373,11 @@ msgstr ""
 "Number |nbsp| / |nbsp| `ID <https://www.esphome.io/guides/configuration-"
 "types#config-id>`_"
 
-#: ../../source/documentation/software_setup.rst:107
+#: ../../source/documentation/software_setup.rst:112
 msgid "50.0"
 msgstr "50.0"
 
-#: ../../source/documentation/software_setup.rst:108
+#: ../../source/documentation/software_setup.rst:113
 msgid ""
 "Schwellwert für die Erkennung einer Umdrehung über den analogen Eingang, "
 "siehe Abschnitt :ref:`Kalibrierung des analogen Ausgangssignals <analog-"
@@ -367,16 +387,16 @@ msgstr ""
 "section :ref:`Calibration of the analog Output Signal <analog-"
 "calibration>` for details"
 
-#: ../../source/documentation/software_setup.rst:109
+#: ../../source/documentation/software_setup.rst:114
 msgid "``off_tolerance``"
 msgstr "``off_tolerance``"
 
-#: ../../source/documentation/software_setup.rst:112
 #: ../../source/documentation/software_setup.rst:117
+#: ../../source/documentation/software_setup.rst:122
 msgid "0.0"
 msgstr "0.0"
 
-#: ../../source/documentation/software_setup.rst:113
+#: ../../source/documentation/software_setup.rst:118
 msgid ""
 "Negativer Versatz zum analogen Schwellwert für die fallende Flanke, siehe"
 " Abschnitt :ref:`Hysterese-Kennlinie <hysteresis-curve>` für Details"
@@ -384,11 +404,11 @@ msgstr ""
 "Negative offset to the analog threshold for the falling edge, see section"
 " :ref:`Hysteresis Curve <hysteresis-curve>` for details"
 
-#: ../../source/documentation/software_setup.rst:114
+#: ../../source/documentation/software_setup.rst:119
 msgid "``on_tolerance``"
 msgstr "``on_tolerance``"
 
-#: ../../source/documentation/software_setup.rst:118
+#: ../../source/documentation/software_setup.rst:123
 msgid ""
 "Positiver Versatz zum analogen Schwellwert für die steigende Flanke, "
 "siehe Abschnitt :ref:`Hysterese-Kennlinie <hysteresis-curve>` für Details"
@@ -396,15 +416,15 @@ msgstr ""
 "Positive offset to the analog threshold for the rising edge, see section "
 ":ref:`Hysteresis Curve <hysteresis-curve>` for details"
 
-#: ../../source/documentation/software_setup.rst:119
+#: ../../source/documentation/software_setup.rst:124
 msgid "``calibrate_on_boot``"
 msgstr "``calibrate_on_boot``"
 
-#: ../../source/documentation/software_setup.rst:120
+#: ../../source/documentation/software_setup.rst:125
 msgid "Objekt"
 msgstr "Object"
 
-#: ../../source/documentation/software_setup.rst:123
+#: ../../source/documentation/software_setup.rst:128
 msgid ""
 "Wenn vorhanden, wird die automatische Kalibrierung des analogen "
 "Ausgangssignals vom Infrarotsensor nach dem Aufstarten ausgeführt, siehe "
@@ -416,7 +436,7 @@ msgstr ""
 ":ref:`Calibration of the analog Output Signal <analog-calibration>` for "
 "details"
 
-#: ../../source/documentation/software_setup.rst:126
+#: ../../source/documentation/software_setup.rst:131
 msgid ""
 "Die folgenden Einstellungen können für das Objekt ``calibrate_on_boot`` "
 "konfiguriert werden:"
@@ -424,33 +444,33 @@ msgstr ""
 "The following configuration items can be configured for the "
 "``calibrate_on_boot`` entry:"
 
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:389
 msgid "``num_captured_values``"
 msgstr "``num_captured_values``"
 
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:389
 msgid "6000"
 msgstr "6000"
 
-#: ../../source/documentation/software_setup.rst:131
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:136
+#: ../../source/documentation/software_setup.rst:389
 msgid "Anzahl der zu erfassenden analogen Werte pro Kalibrierungsdurchlauf"
 msgstr "Number of analog values to capture per calibration iteration"
 
-#: ../../source/documentation/software_setup.rst:133
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:391
 msgid "``min_level_distance``"
 msgstr "``min_level_distance``"
 
-#: ../../source/documentation/software_setup.rst:133
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:391
 msgid "6.0"
 msgstr "6.0"
 
-#: ../../source/documentation/software_setup.rst:133
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:138
+#: ../../source/documentation/software_setup.rst:391
 msgid ""
 "Mindestdifferenz zwischen niedrigstem und höchstem Analogwert, damit die "
 "Kalibrierung als erfolgreich angesehen und der analoge Schwellwert "
@@ -459,24 +479,24 @@ msgstr ""
 "Minimum difference between lowest and highest analog value to accept the "
 "calibration and set the analog threshold"
 
-#: ../../source/documentation/software_setup.rst:136
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:141
+#: ../../source/documentation/software_setup.rst:393
 msgid "``max_iterations``"
 msgstr "``max_iterations``"
 
-#: ../../source/documentation/software_setup.rst:136
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:141
+#: ../../source/documentation/software_setup.rst:393
 msgid "3"
 msgstr "3"
 
-#: ../../source/documentation/software_setup.rst:136
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:141
+#: ../../source/documentation/software_setup.rst:393
 msgid ""
 "Maximale Anzahl fehlgeschlagener Kalibrierungsdurchläufe, bevor "
 "aufgegeben wird"
 msgstr "Maximum number of failed calibration iterations before giving up"
 
-#: ../../source/documentation/software_setup.rst:140
+#: ../../source/documentation/software_setup.rst:145
 msgid ""
 "Bestimmte :ref:`Anwendungsfälle <usage-examples>` benötigen das "
 "Konfigurationselement ``id``."
@@ -484,16 +504,7 @@ msgstr ""
 "Some :ref:`use cases <usage-examples>` require the configuration element "
 "``id``."
 
-#: ../../source/documentation/software_setup.rst:142
-msgid ""
-"Nur eines der beiden Konfigurationselemente - ``digital_input`` oder "
-"``analog_input`` - wird benötigt, je nach :ref:`Hardware-Aufbauvariante "
-"<hardware-setup>`."
-msgstr ""
-"Only one of ``digital_input`` or ``analog_input`` is required, depending "
-"on the :ref:`hardware setup variant <hardware-setup>`."
-
-#: ../../source/documentation/software_setup.rst:144
+#: ../../source/documentation/software_setup.rst:147
 msgid ""
 "Die Konfigurationselemente ``analog_threshold``\\ , ``off_tolerance``\\ ,"
 " ``on_tolerance`` und ``debounce_threshold`` erwarten entweder eine feste"
@@ -511,11 +522,20 @@ msgstr ""
 "`template number "
 "<https://www.esphome.io/components/number/template.html>`_)."
 
-#: ../../source/documentation/software_setup.rst:159
+#: ../../source/documentation/software_setup.rst:149
+msgid ""
+"Nur eines der beiden Konfigurationselemente - ``digital_input`` oder "
+"``analog_input`` - wird benötigt, je nach :ref:`Hardware-Aufbauvariante "
+"<hardware-setup>`."
+msgstr ""
+"Only one of ``digital_input`` or ``analog_input`` is required, depending "
+"on the :ref:`hardware setup variant <hardware-setup>`."
+
+#: ../../source/documentation/software_setup.rst:164
 msgid "API/MQTT-Komponente"
 msgstr "API/MQTT Component"
 
-#: ../../source/documentation/software_setup.rst:161
+#: ../../source/documentation/software_setup.rst:166
 msgid ""
 "Eine `API-Komponente <https://www.esphome.io/components/api.html>`_ ist "
 "erforderlich, wenn der ESP in Home Assistant integriert werden soll. Für "
@@ -534,7 +554,7 @@ msgstr ""
 "energy meter or restoring the last meter reading after a restart (see "
 "below for details) will then possibly no longer work."
 
-#: ../../source/documentation/software_setup.rst:166
+#: ../../source/documentation/software_setup.rst:171
 msgid ""
 "Nachfolgend ein Beispiel für die Integration mit Home Assistant (und "
 "verschlüsselter API):"
@@ -542,7 +562,7 @@ msgstr ""
 "See below example for the integration into Home Assistant (with encrypted"
 " API):"
 
-#: ../../source/documentation/software_setup.rst:174
+#: ../../source/documentation/software_setup.rst:179
 msgid ""
 "Und hier ein Beispiel für die Verwendung mit einer alternativen "
 "Hausautomatisierungs-Software mittels MQTT:"
@@ -550,11 +570,11 @@ msgstr ""
 "And below an example for usage with an alternative home automation "
 "software via MQTT:"
 
-#: ../../source/documentation/software_setup.rst:184
+#: ../../source/documentation/software_setup.rst:189
 msgid "WiFi-Komponente"
 msgstr "WiFi Component"
 
-#: ../../source/documentation/software_setup.rst:186
+#: ../../source/documentation/software_setup.rst:191
 msgid ""
 "Eine `WiFi-Komponente <https://www.esphome.io/components/wifi.html>`_ "
 "sollte vorhanden sein, da die Sensor-Werte ansonsten nicht ohne weiteres "
@@ -564,11 +584,11 @@ msgstr ""
 "be present, as otherwise the sensor values cannot be easily transmitted "
 "to another computer."
 
-#: ../../source/documentation/software_setup.rst:198
+#: ../../source/documentation/software_setup.rst:203
 msgid "Sensoren"
 msgstr "Sensors"
 
-#: ../../source/documentation/software_setup.rst:200
+#: ../../source/documentation/software_setup.rst:205
 msgid ""
 "Die Ferraris-Plattform verfügt über primäre Sensoren, um die berechneten "
 "Verbrauchswerte auszugeben sowie über diagnostische Sensoren für den "
@@ -579,78 +599,78 @@ msgstr ""
 "consumption values as well as diagnostic sensors for the calibration "
 "mode. All sensors are optional and can be omitted if not needed."
 
-#: ../../source/documentation/software_setup.rst:205
+#: ../../source/documentation/software_setup.rst:210
 msgid "Primäre Sensoren"
 msgstr "Primary Sensors"
 
-#: ../../source/documentation/software_setup.rst:207
+#: ../../source/documentation/software_setup.rst:212
 msgid "Die folgenden primären Sensoren können konfiguriert werden:"
 msgstr "The following primary sensors can be configured:"
 
-#: ../../source/documentation/software_setup.rst:210
-#: ../../source/documentation/software_setup.rst:243
+#: ../../source/documentation/software_setup.rst:215
+#: ../../source/documentation/software_setup.rst:248
 msgid "Sensor"
 msgstr "Sensor"
 
-#: ../../source/documentation/software_setup.rst:210
+#: ../../source/documentation/software_setup.rst:215
 msgid "Geräteklasse"
 msgstr "Device Class"
 
-#: ../../source/documentation/software_setup.rst:210
+#: ../../source/documentation/software_setup.rst:215
 msgid "Zustandsklasse"
 msgstr "State Class"
 
-#: ../../source/documentation/software_setup.rst:210
+#: ../../source/documentation/software_setup.rst:215
 msgid "Einheit"
 msgstr "Unit"
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "``power_consumption``"
 msgstr "``power_consumption``"
 
-#: ../../source/documentation/software_setup.rst:212
-#: ../../source/documentation/software_setup.rst:214
-#: ../../source/documentation/software_setup.rst:256
+#: ../../source/documentation/software_setup.rst:217
+#: ../../source/documentation/software_setup.rst:219
+#: ../../source/documentation/software_setup.rst:261
 msgid "numerisch"
 msgstr "numeric"
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "``power``"
 msgstr "``power``"
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "``measurement``"
 msgstr "``measurement``"
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "W"
 msgstr "W"
 
-#: ../../source/documentation/software_setup.rst:212
+#: ../../source/documentation/software_setup.rst:217
 msgid "Aktueller Stromverbrauch"
 msgstr "Current power consumption"
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "``energy_meter``"
 msgstr "``energy_meter``"
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "``energy``"
 msgstr "``energy``"
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "``total_increasing``"
 msgstr "``total_increasing``"
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "Wh"
 msgstr "Wh"
 
-#: ../../source/documentation/software_setup.rst:214
+#: ../../source/documentation/software_setup.rst:219
 msgid "Gesamtstromverbrauch (Stromzähler/Zählerstand)"
 msgstr "Total energy consumption (meter reading)"
 
-#: ../../source/documentation/software_setup.rst:219
+#: ../../source/documentation/software_setup.rst:224
 msgid ""
 "Detaillierte Informationen zu den Konfigurationsmöglichkeiten der "
 "einzelnen Elemente findest du in der Dokumentation der `ESPHome "
@@ -660,25 +680,25 @@ msgstr ""
 "`sensor component configuration "
 "<https://www.esphome.io/components/sensor>`_."
 
-#: ../../source/documentation/software_setup.rst:236
+#: ../../source/documentation/software_setup.rst:241
 msgid "Diagnostische Sensoren"
 msgstr "Diagnostic Sensors"
 
-#: ../../source/documentation/software_setup.rst:238
+#: ../../source/documentation/software_setup.rst:243
 msgid "Die folgenden diagnostischen Sensoren können konfiguriert werden:"
 msgstr "The following diagnostic sensors can be configured:"
 
-#: ../../source/documentation/software_setup.rst:246
+#: ../../source/documentation/software_setup.rst:251
 msgid "``rotation_indicator``"
 msgstr "``rotation_indicator``"
 
-#: ../../source/documentation/software_setup.rst:247
-#: ../../source/documentation/software_setup.rst:250
-#: ../../source/documentation/software_setup.rst:253
+#: ../../source/documentation/software_setup.rst:252
+#: ../../source/documentation/software_setup.rst:255
+#: ../../source/documentation/software_setup.rst:258
 msgid "binär"
 msgstr "binary"
 
-#: ../../source/documentation/software_setup.rst:248
+#: ../../source/documentation/software_setup.rst:253
 msgid ""
 "Zeigt an, ob die Markierung auf der Drehscheibe gerade vor dem "
 "Infrarotsensor ist (funktioniert nur im Kalibrierungsmodus)"
@@ -686,29 +706,29 @@ msgstr ""
 "Indicates if the mark on the turntable is in front of the infrared sensor"
 " (only works in calibration mode)"
 
-#: ../../source/documentation/software_setup.rst:249
+#: ../../source/documentation/software_setup.rst:254
 msgid "``analog_calibration_state``"
 msgstr "``analog_calibration_state``"
 
-#: ../../source/documentation/software_setup.rst:251
+#: ../../source/documentation/software_setup.rst:256
 msgid "Status der automatischen analogen Kalibrierung (ob aktiv oder nicht)"
 msgstr "State of the automatic analog calibration (if running or not)"
 
-#: ../../source/documentation/software_setup.rst:252
+#: ../../source/documentation/software_setup.rst:257
 msgid "``analog_calibration_result``"
 msgstr "``analog_calibration_result``"
 
-#: ../../source/documentation/software_setup.rst:254
+#: ../../source/documentation/software_setup.rst:259
 msgid ""
 "Ergebnis der letzten automatischen analogen Kalibrierung (ob erfolgreich "
 "oder nicht)"
 msgstr "Result of the latest automatic analog calibration (if successful or not)"
 
-#: ../../source/documentation/software_setup.rst:255
+#: ../../source/documentation/software_setup.rst:260
 msgid "``analog_value_spectrum``"
 msgstr "``analog_value_spectrum``"
 
-#: ../../source/documentation/software_setup.rst:257
+#: ../../source/documentation/software_setup.rst:262
 msgid ""
 "Bandbreite der analogen Werte (Differenz zwischen kleinstem und größtem "
 "analogen Wert)"
@@ -716,7 +736,7 @@ msgstr ""
 "Spectrum of the analog values (difference between lowest and highest "
 "analog value)"
 
-#: ../../source/documentation/software_setup.rst:260
+#: ../../source/documentation/software_setup.rst:265
 msgid ""
 "Detaillierte Informationen zu den Konfigurationsmöglichkeiten der "
 "einzelnen Elemente findest du in der Dokumentation der `ESPHome "
@@ -730,11 +750,11 @@ msgstr ""
 "`sensor component configuration "
 "<https://www.esphome.io/components/sensor>`_."
 
-#: ../../source/documentation/software_setup.rst:284
+#: ../../source/documentation/software_setup.rst:289
 msgid "Aktoren"
 msgstr "Actors"
 
-#: ../../source/documentation/software_setup.rst:286
+#: ../../source/documentation/software_setup.rst:291
 msgid ""
 "Zu diagnostischen Zwecken verfügt die Ferraris-Plattform über einen "
 "`Schalter <https://www.esphome.io/components/switch>`_. Dieser hat den "
@@ -748,11 +768,11 @@ msgstr ""
 "mode (see section :ref:`calibration <calibration>` for further "
 "information)."
 
-#: ../../source/documentation/software_setup.rst:301
+#: ../../source/documentation/software_setup.rst:306
 msgid "Aktionen"
 msgstr "Actions"
 
-#: ../../source/documentation/software_setup.rst:303
+#: ../../source/documentation/software_setup.rst:308
 msgid ""
 "Die Ferraris-Plattform stellt verschiedene Aktionen zur Verfügung, um "
 "Werte zu setzen oder das Verhalten zu steuern."
@@ -760,50 +780,50 @@ msgstr ""
 "The Ferraris platform provides various actions for setting values or "
 "controlling the behavior."
 
-#: ../../source/documentation/software_setup.rst:306
+#: ../../source/documentation/software_setup.rst:311
 msgid "Zählerstand setzen"
 msgstr "Set Energy Meter"
 
-#: ../../source/documentation/software_setup.rst:314
+#: ../../source/documentation/software_setup.rst:319
 msgid "Setzt den Zählerstand auf den angegeben Wert."
 msgstr "Sets the energy meter reading to the provided value"
 
-#: ../../source/documentation/software_setup.rst:317
-#: ../../source/documentation/software_setup.rst:320
-#: ../../source/documentation/software_setup.rst:350
-#: ../../source/documentation/software_setup.rst:353
-#: ../../source/documentation/software_setup.rst:377
+#: ../../source/documentation/software_setup.rst:322
+#: ../../source/documentation/software_setup.rst:325
+#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:358
 #: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:387
 msgid "Parameter"
 msgstr "Parameter"
 
-#: ../../source/documentation/software_setup.rst:320
-#: ../../source/documentation/software_setup.rst:353
-#: ../../source/documentation/software_setup.rst:382
+#: ../../source/documentation/software_setup.rst:325
+#: ../../source/documentation/software_setup.rst:358
+#: ../../source/documentation/software_setup.rst:387
 msgid "Bereich"
 msgstr "Range"
 
-#: ../../source/documentation/software_setup.rst:322
-#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:327
+#: ../../source/documentation/software_setup.rst:360
 msgid "``value``"
 msgstr "``value``"
 
-#: ../../source/documentation/software_setup.rst:322
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:327
+#: ../../source/documentation/software_setup.rst:391
 msgid "``float``"
 msgstr "``float``"
 
-#: ../../source/documentation/software_setup.rst:322
-#: ../../source/documentation/software_setup.rst:386
+#: ../../source/documentation/software_setup.rst:327
+#: ../../source/documentation/software_setup.rst:391
 msgid ">= 0"
 msgstr ">= 0"
 
-#: ../../source/documentation/software_setup.rst:322
+#: ../../source/documentation/software_setup.rst:327
 msgid "Zielwert für den Zählerstand in Kilowattstunden (kWh)"
 msgstr "Target value for the energy meter reading in kilowatt hours (kWh)"
 
-#: ../../source/documentation/software_setup.rst:326
-#: ../../source/documentation/software_setup.rst:359
+#: ../../source/documentation/software_setup.rst:331
+#: ../../source/documentation/software_setup.rst:364
 msgid ""
 "Anstelle eines festen Zahlenwerts kann auch ein Lambda-Ausdruck verwendet"
 " werden, der den zu übergebenden Wert zurückgibt."
@@ -811,7 +831,7 @@ msgstr ""
 "Instead of a fixed numeric value, it is also possible to specify a lambda"
 " expression that returns the value to be passed to the action."
 
-#: ../../source/documentation/software_setup.rst:330
+#: ../../source/documentation/software_setup.rst:335
 msgid ""
 "Obwohl der Sensor für den aktuellen Zählerstand die Einheit **Wh "
 "(Wattstunden)** hat, verwendet die Aktion zum Überschreiben des "
@@ -824,15 +844,15 @@ msgstr ""
 "**kWh (kilowatt hours)**\\ , as the analog Ferraris electricity meters "
 "usually also display the meter reading in this unit."
 
-#: ../../source/documentation/software_setup.rst:334
+#: ../../source/documentation/software_setup.rst:339
 msgid "Umdrehungszähler setzen"
 msgstr "Set Rotation Counter"
 
-#: ../../source/documentation/software_setup.rst:342
+#: ../../source/documentation/software_setup.rst:347
 msgid "Setzt den Umdrehungszähler auf den angegeben Wert."
 msgstr "Sets the rotation counter to the provided value"
 
-#: ../../source/documentation/software_setup.rst:346
+#: ../../source/documentation/software_setup.rst:351
 msgid ""
 "Die Aktion zum Setzen des Zählerstands setzt indirekt auch den "
 "Umdrehungszähler, da die Ferraris-Komponente intern mit Umdrehungen und "
@@ -842,23 +862,23 @@ msgstr ""
 "rotation counter as the Ferraris component internally works with "
 "rotations and not with watt hours or kilowatt hours."
 
-#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:360
 msgid "``uint64``"
 msgstr "``uint64``"
 
-#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:360
 msgid "\\>= 0"
 msgstr "\\>= 0"
 
-#: ../../source/documentation/software_setup.rst:355
+#: ../../source/documentation/software_setup.rst:360
 msgid "Zielwert für den Umdrehungszähler in Anzahl Umdrehungen"
 msgstr "Target value for the rotation counter in number of rotations"
 
-#: ../../source/documentation/software_setup.rst:362
+#: ../../source/documentation/software_setup.rst:367
 msgid "Automatische analoge Kalibrierung"
 msgstr "Automatic analog Calibration"
 
-#: ../../source/documentation/software_setup.rst:372
+#: ../../source/documentation/software_setup.rst:377
 msgid ""
 "Startet die automatische Kalibrierung des analogen Ausgangssignals vom "
 "Infrarotsensor."
@@ -866,34 +886,40 @@ msgstr ""
 "Starts the automatic calibration of the analog output signal from the "
 "infrared sensor"
 
-#: ../../source/documentation/software_setup.rst:374
+#: ../../source/documentation/software_setup.rst:379
 msgid ""
 "Wird die Mindestdifferenz zwischen niedrigstem und höchstem Analogwert "
 "nach Erfassen aller Werte nicht erreicht, gilt die Kalibrierung als "
 "fehlgeschlagen und ein neuer Durchlauf wird gestartet (bis die maximale "
 "Anzahl Durchläufe erreicht wurde)."
 msgstr ""
-"If the minimum difference between the lowest and highest analog values "
-"is not achieved after all values have been captured, the calibration is "
+"If the minimum difference between the lowest and highest analog values is"
+" not achieved after all values have been captured, the calibration is "
 "considered to have failed and a new run is started (until the maximum "
 "number of runs has been reached)."
 
-#: ../../source/documentation/software_setup.rst:379
+#: ../../source/documentation/software_setup.rst:384
 msgid "Alle Parameter sind optional und können weggelassen werden."
 msgstr "All parameters are optional and can be omitted."
 
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:389
 msgid "``uint32``"
 msgstr "``uint32``"
 
-#: ../../source/documentation/software_setup.rst:384
+#: ../../source/documentation/software_setup.rst:389
 msgid "100 |nbsp| ... |nbsp| 100000"
 msgstr "100 |nbsp| ... |nbsp| 100000"
 
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:393
 msgid "``uint16``"
 msgstr "``uint16``"
 
-#: ../../source/documentation/software_setup.rst:388
+#: ../../source/documentation/software_setup.rst:393
 msgid "1 |nbsp| ... |nbsp| 10000"
 msgstr "1 |nbsp| ... |nbsp| 10000"
+
+#~ msgid ""
+#~ "Dauer des Interpolationsintervalls in "
+#~ "Sekunden, ``0``, um die Interpolation "
+#~ "auszuschalten"
+#~ msgstr ""

--- a/doc/source/locale/en/LC_MESSAGES/documentation/usage_examples.po
+++ b/doc/source/locale/en/LC_MESSAGES/documentation/usage_examples.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ESPHome Ferraris Meter \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-02-16 19:56+0100\n"
+"POT-Creation-Date: 2026-03-25 19:27+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Jens-Uwe Rossbach <devel@jrossbach.de>\n"
 "Language: en\n"
@@ -405,7 +405,7 @@ msgstr ""
 
 #: ../../source/documentation/usage_examples.rst:202
 msgid "Analoger Schwellwert"
-msgstr "Debounce Threshold"
+msgstr "Analog Threshold"
 
 #: ../../source/documentation/usage_examples.rst:209
 msgid ""
@@ -691,11 +691,64 @@ msgstr ""
 "update interval. Also this type of debouncing only works when using the "
 "analog input signal of the infrared sensor."
 
-#: ../../source/documentation/usage_examples.rst:445
+#: ../../source/documentation/usage_examples.rst:447
+msgid "Interpolation bei fallenden Stromverbräuchen"
+msgstr "Interpolation at falling Power Consumption"
+
+#: ../../source/documentation/usage_examples.rst:449
+msgid ""
+"Niedrige Stromverbräuche äußern sich in einer langsamen Geschwindigkeit "
+"der Drehscheibe. Dies führt dazu, dass die Markierung auf der Drehscheibe"
+" nur selten am Sensor vorbei fährt und dadurch aktualisiert sich der "
+"Stromverbrauch ebensfalls nur in großen Zeitabständen. Besonders störend "
+"ist dies, wenn ein hoher Stromverbrauch vorliegt und dieser sich dann "
+"rasch absenkt. In diesem Fall dauert es sehr lang, bis der neue niedrige "
+"Stromverbrauch gemeldet wird, da es lange dauert, bis die Markierung "
+"wieder den Sensor passiert. In dieser Zeit wird dann weiterhin ein hoher "
+"Stromverbrauch angezeigt, obwohl der tatsächliche Stromverbrauch viel "
+"niedriger ist."
+msgstr ""
+"Low power consumption results in a slow rotation speed of the turntable. "
+"This means that the marker on the turntable rarely passes the sensor, so "
+"the power consumption is updated only at long intervals. This is "
+"particularly problematic when power consumption is high and then drops "
+"rapidly. In this case, it takes a very long time for the new low power "
+"consumption to be reported, since it takes a long time for the mark to "
+"pass the sensor again. During this time, high power consumption continues"
+" to be displayed, even though the actual power consumption is much lower."
+
+#: ../../source/documentation/usage_examples.rst:451
+msgid ""
+"Um diesem Effekt entgegenzuwirken, kann die Ferraris-Komponente bei "
+"Übergängen von hohen zu niedrigen Stromverbräuchen den tatsächlichen "
+"Verbrauchsverlauf interpolieren und sich somit dem tatsächlichen "
+"Stromverbrauch immer weiter annähern, bis der tatsächliche Stromverbrauch"
+" nach Detektierung der Markierung berechnet und gemeldet wird."
+msgstr ""
+"To counteract this effect, the Ferraris component can, during "
+"transitions from high to low power consumption, interpolate the actual "
+"consumption curve and thus progressively approximate the real power "
+"consumption until the actual power consumption is calculated and reported"
+" after the marker is detected. "
+
+#: ../../source/documentation/usage_examples.rst:453
+msgid ""
+"Die Interpolation kann über das Interpolationsintervall "
+"``interpolation_interval`` gesteuert werden. Ein Wert von ``0`` "
+"deaktiviert die Interpolation, ansonsten gibt der Wert die Dauer der "
+"Intervalle in Sekunden an, zu denen ein interpolierter Stromverbrauch "
+"berechnet wird."
+msgstr ""
+"Interpolation can be controlled via the interpolation interval value "
+"``interpolation_interval``. A value of ``0`` disables interpolation; "
+"otherwise, the value specifies the duration of the intervals in seconds "
+"for which an interpolated power consumption is calculated."
+
+#: ../../source/documentation/usage_examples.rst:456
 msgid "Manuelles Überschreiben des Zählerstands"
 msgstr "Explicit Meter Reading Replacement"
 
-#: ../../source/documentation/usage_examples.rst:447
+#: ../../source/documentation/usage_examples.rst:458
 msgid ""
 "Um den Zählerstand in der Ferraris-Komponente mit dem tatsächlichen "
 "Zählerstand des Ferraris-Stromzählers abzugleichen, kann der Wert des "
@@ -710,7 +763,7 @@ msgstr ""
 "``ferraris.set_energy_meter`` and ``ferraris.set_rotation_counter`` (see "
 ":ref:`Actions <actions>`) are provided for this purpose."
 
-#: ../../source/documentation/usage_examples.rst:451
+#: ../../source/documentation/usage_examples.rst:462
 msgid ""
 "Normalerweise ist nur eine der beiden Aktionen nötig, je nachdem, ob man "
 "den Zählerstand in Kilowattstunden oder lieber in Anzahl Umdrehungen "
@@ -720,7 +773,7 @@ msgstr ""
 "whether you want to set the meter reading in kilowatt hours or in number "
 "of rotations."
 
-#: ../../source/documentation/usage_examples.rst:454
+#: ../../source/documentation/usage_examples.rst:465
 msgid ""
 "Abhängig davon, ob das Setzen des Zählerstands händisch über das User-"
 "Interface oder automatisiert über Automationen und Skripte erfolgen soll,"
@@ -734,11 +787,11 @@ msgstr ""
 "are described below, but there are more possibilities existing which are "
 "not described here."
 
-#: ../../source/documentation/usage_examples.rst:457
+#: ../../source/documentation/usage_examples.rst:468
 msgid "Händisches Setzen des Zählerstands über das User-Interface"
 msgstr "Setting Energy Meter manually via the User Interface"
 
-#: ../../source/documentation/usage_examples.rst:459
+#: ../../source/documentation/usage_examples.rst:470
 msgid ""
 "Dafür führt man beispielsweise folgende Konfigurations-Schritte durch (in"
 " diesem Beispiel zum Setzen des Zählerstands als Kilowattstunden-Wert):"
@@ -746,7 +799,7 @@ msgstr ""
 "For instance, the following configuration steps are carried out (in this "
 "example to overwrite the energy meter with a kilowatt hours value):"
 
-#: ../../source/documentation/usage_examples.rst:461
+#: ../../source/documentation/usage_examples.rst:472
 msgid ""
 "In der YAML-Konfigurationsdatei wird eine `Template-Zahlen-Komponente "
 "<https://www.esphome.io/components/number/template.html>`_ angelegt und "
@@ -757,7 +810,7 @@ msgstr ""
 "the YAML configuration file and configured for a meter reading in the "
 "unit kilowatt hours."
 
-#: ../../source/documentation/usage_examples.rst:479
+#: ../../source/documentation/usage_examples.rst:490
 msgid ""
 "In der YAML-Konfigurationsdatei wird ein `Template-Button "
 "<https://www.esphome.io/components/button/template.html>`_ angelegt und "
@@ -772,15 +825,15 @@ msgstr ""
 " The target value to be set is retrieved from the created number "
 "component"
 
-#: ../../source/documentation/usage_examples.rst:496
+#: ../../source/documentation/usage_examples.rst:507
 msgid "Automatisiertes Setzen des Zählerstands"
 msgstr "Setting Energy Meter automatically"
 
-#: ../../source/documentation/usage_examples.rst:498
+#: ../../source/documentation/usage_examples.rst:509
 msgid "Dafür führt man beispielsweise folgende Konfigurations-Schritte durch:"
 msgstr "For instance, the following configuration steps are carried out:"
 
-#: ../../source/documentation/usage_examples.rst:500
+#: ../../source/documentation/usage_examples.rst:511
 msgid ""
 "In der YAML-Konfigurationsdatei wird eine `benutzerdefinierte Aktion "
 "<https://www.esphome.io/components/api.html#api-device-actions>`_ "
@@ -792,7 +845,7 @@ msgstr ""
 "one of the Ferraris actions (in the following example the action "
 "``ferraris.set_energy_meter`` is used)."
 
-#: ../../source/documentation/usage_examples.rst:518
+#: ../../source/documentation/usage_examples.rst:529
 msgid ""
 "In Home Assistant wird eine `Automation <https://www.home-"
 "assistant.io/docs/automation>`_ erstellt, die die benutzerdefinierte "
@@ -804,11 +857,11 @@ msgstr ""
 "the following example, the meter reading is reset at the beginning of "
 "each month)."
 
-#: ../../source/documentation/usage_examples.rst:537
+#: ../../source/documentation/usage_examples.rst:548
 msgid "Wiederherstellung des Zählerstands nach einem Neustart"
 msgstr "Meter Reading Recovery after Restart"
 
-#: ../../source/documentation/usage_examples.rst:539
+#: ../../source/documentation/usage_examples.rst:550
 msgid ""
 "Um die Lebensdauer des Flash-Speichers auf dem ESP-Mikrocontroller nicht "
 "zu verringern, speichert die Ferraris-Komponente keine Daten persistent "
@@ -831,13 +884,13 @@ msgstr ""
 " there is the option of persisting the last meter reading in Home "
 "Assistant and transferring it to the microcontroller when booting."
 
-#: ../../source/documentation/usage_examples.rst:541
+#: ../../source/documentation/usage_examples.rst:552
 msgid ""
 "Damit dies funktioniert, müssen beispielsweise folgende Konfigurations-"
 "Schritte durchgeführt werden:"
 msgstr "For this to work, the following configuration steps must be carried out:"
 
-#: ../../source/documentation/usage_examples.rst:544
+#: ../../source/documentation/usage_examples.rst:555
 msgid ""
 "In Home Assistant wird ein `Zahlenwert-Eingabehelfer <https://www.home-"
 "assistant.io/integrations/input_number>`_ angelegt (in diesem Beispiel "
@@ -856,7 +909,7 @@ msgstr ""
 "created in the YAML configuration file, which imports the created number "
 "input helper"
 
-#: ../../source/documentation/usage_examples.rst:553
+#: ../../source/documentation/usage_examples.rst:564
 msgid ""
 "Unter der Konfiguration der Ferraris-Komponente verweist der Eintrag "
 "``energy_start_value`` auf die angelegte Zahlen-Komponente."
@@ -864,7 +917,7 @@ msgstr ""
 "Under the configuration of the Ferraris component, the entry "
 "``energy_start_value`` refers to the created number component."
 
-#: ../../source/documentation/usage_examples.rst:561
+#: ../../source/documentation/usage_examples.rst:572
 msgid ""
 "In Home Assistant wird eine `Automation <https://www.home-"
 "assistant.io/docs/automation/basics>`_ erstellt, die bei Änderung des "
@@ -875,7 +928,7 @@ msgstr ""
 "is created in Home Assistant that copies the current sensor value to the "
 "created number input helper. when the energy meter sensor is changed."
 
-#: ../../source/documentation/usage_examples.rst:580
+#: ../../source/documentation/usage_examples.rst:591
 msgid ""
 "Alternativ kann auch eine `Sensor-Automation "
 "<https://www.esphome.io/components/sensor/#sensor-automation>`_ für den "
@@ -919,4 +972,25 @@ msgstr ""
 #~ msgstr ""
 
 #~ msgid "Analog Threshold"
+#~ msgstr ""
+
+#~ msgid ""
+#~ "Niedrige Stromverbräuche äußern sich in "
+#~ "einer langsamen Geschwindigkeit der "
+#~ "Drehscheibe. Dies führt dazu, dass die"
+#~ " Markierung auf der Drehscheibe nur "
+#~ "selten am Sensor vorbei fährt und "
+#~ "dadurch aktualisiert sich der Stromverbrauch"
+#~ " ebensfalls nur in großen Zeitabständen."
+#~ " Besonders störend ist dies, wenn ein"
+#~ " hoher Stromverbrauch vorliegt und dieser"
+#~ " sich dann rasch absenkt. In diesem"
+#~ " Fall dauert es sehr lang, bis "
+#~ "der neue niedrige Stromverbrauch gemeldet "
+#~ "wird, da es lange dauert, bis die"
+#~ " Markierung wieder den Sensor passiert. "
+#~ "In dieser Zeit wird dann weiterhin "
+#~ "ein hoher Stromverbrauch angezeigt, obwohl "
+#~ "der tatsächliche Stromverbrauch viel nidriger"
+#~ " ist."
 #~ msgstr ""


### PR DESCRIPTION
Low power consumption results in a slow rotation speed of the turntable. This means that the marker on the turntable rarely passes the sensor, so the power consumption is updated only at long intervals. This is particularly problematic when power consumption is high and then drops rapidly. In this case, it takes a very long time for the new low power consumption to be reported, since it takes a long time for the mark to pass the sensor again. During this time, high power consumption continues to be displayed, even though the actual power consumption is much lower.

To counteract this effect, the Ferraris component can now interpolate the actual consumption curve during transitions from high to low power consumption and thus progressively approximate the real power consumption until the actual power consumption is calculated and reported after the marker is detected.

Implements #71